### PR TITLE
Fix the wrong-coordinate weather, the server-killing error path, and the unescaped markup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,19 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Logs
+*.log
+
+# Anything shaped like a credential. This project reads three API keys from .env.
+*.pem
+*.key
+credentials*
+secrets/
+
+# Local databases
+*.sqlite
+*.db
+
+# Python bytecode, in case anything gets scripted alongside
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ named `jest-html-reporter` in its `reporters` block, and that package is in **ne
 `package.json` nor `package-lock.json`. Jest resolves reporters before running anything, so
 `npm test` could not start at all.
 
-There are **64 tests** now, over seven suites, covering every fix above. Each one was
+There are **84 tests** now, over eight suites, covering every fix above. Each one was
 poison-tested: the fix was reverted and the suite checked to go red, so none of them passes
 vacuously.
 
@@ -163,6 +163,11 @@ those `alt` attributes needs a *valid* icon with a hostile description. Likewise
 hostile icon only to `forecastMin` left the current-weather allowlist untested, since
 `currentMin.icon` only ever saw `c02d`.
 
+**And a guard nothing can reach is not defence, it is noise.** `markupCity` was given a
+`|| {}` that no test could exercise, because its only caller passes an already-normalised
+object and it is not exported. Reverting that guard left all 84 tests green, which is the
+signature of dead code rather than of a coverage gap. It was removed rather than tested.
+
 All ten guarded values in `markup.js` are now poison-tested individually, and each one fails
 on its own.
 
@@ -192,7 +197,7 @@ Lint is clean now too; it was not. `npx eslint src` reported 3 errors on `master
 
 Three API keys are needed, all free:
 
-1. [Geonames](http://www.geonames.org/export/web-services.html) — a username, not a key
+1. [Geonames](https://www.geonames.org/export/web-services.html) — a username, not a key
 2. [Weatherbit](https://www.weatherbit.io/account/create)
 3. [Pixabay](https://pixabay.com/api/docs/)
 
@@ -213,11 +218,23 @@ npm run prod:build
 npm run prod:start     # PORT is honoured, defaulting to 8085
 ```
 
-Optionally, if the bundle is served from a different origin than the API:
+### If the bundle and the API are on different origins
 
-```shell
-CORS_ORIGIN=https://your-site.example npm run prod:start
-```
+`CORS_ORIGIN` alone does **not** achieve this, and an earlier version of this README implied it
+did. The client posts to `/api/travels`, a root-relative path, so the browser always sends it to
+whichever origin served the bundle. `CORS_ORIGIN` authorises an origin on the API side; it does
+not change where the request goes.
+
+So a split deployment needs one of:
+
+- **A reverse proxy** on the bundle's origin forwarding `/api` to the API server. Nothing
+  changes in this code, and `CORS_ORIGIN` is not needed either, because the browser still sees
+  one origin.
+- **An absolute API base URL** compiled into the client, which this project does not have. That
+  is the change to make if you want a genuinely separate API host, and then `CORS_ORIGIN` on the
+  server is what authorises it.
+
+`CORS_ORIGIN` is still worth setting if something other than this bundle calls the API.
 
 ### Node 14 to 20. Not 22 or newer.
 

--- a/README.md
+++ b/README.md
@@ -1,61 +1,214 @@
 # API of APIs
 
-## Overview
+[![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
 
-TO ADD...
+One request fanned out to three public APIs and composed server-side. You type a city and a
+date range; the server geocodes the city with **geonames**, asks **weatherbit** for current
+conditions and a forecast for those coordinates, fetches a photo from **pixabay**, and
+returns a single object. Built March 2021 as Udacity's travel-app project.
 
-This app requires 3 API keys...
+The point of the shape is that the browser never sees an API key. The client posts to
+`/api/travels` and the three keyed calls happen on the server.
 
-1. [Geonames](http://www.geonames.org/export/web-services.html)
-1. [Weatherbit](https://www.weatherbit.io/account/create)
-1. [Pixabay](https://pixabay.com/api/docs/)
+The overview here used to read `TO ADD...`, so this is the first version that describes
+the project.
 
-Once you have the API keys, use the `.env-sample` to generate the proper `.env` file. 
+## What changed, and why
 
-## Instructions
+The app worked in the sense that a happy path returned data. Under that, a handful of things
+were quietly wrong. Each item below was measured, and the commands are in the repository's
+test suite so they cannot drift.
 
-### Install dependencies
+**The weather was for the wrong place.** One line in `src/server/API/weatherbit.js` built
+the request URL, and it had two bugs:
 
+```js
+`${baseURL}${api}/daily?key=${apiKey}&lat=${lat}6&lon=${lng}`
 ```
+
+The `6` after `${lat}` appended a digit to every latitude. Measured: a latitude of `40.7128`
+was sent as `lat=40.71286`. Nothing errored, the API simply answered about somewhere else,
+and how far off depended on how many decimal places the coordinate happened to have.
+
+`${api}/daily` was also only right for one of its two callers. Per Weatherbit's
+documentation the current-conditions endpoint is `/v2.0/current` and **there is no
+`/current/daily`**; the 16-day forecast is `/v2.0/forecast/daily`. So the current-weather
+call was requesting a path that does not exist.
+
+**A failed upstream call took the server with it.** The route was `async` and Express 4 does
+not catch a rejected promise from an async handler. The three `catch` blocks in the API
+modules `return err`, so an error object flowed onward as if it were data, and the parsers
+did `for (let obj of apiResponse.geonames)` on it. Measured against express 4.17.1:
+
+| runtime | what a failed upstream call did |
+| --- | --- |
+| Node 14 | `TypeError: objArr is not iterable`, then the request **hangs with no response** (3020 ms, no reply) |
+| Node 15+ | the same TypeError, then the **process exits with code 1** |
+
+So one bad response from a third party either hung the client forever or killed the server.
+The parsers return an empty result instead of throwing, and the route is wrapped so anything
+unexpected becomes a `502` with a message.
+
+**A validation function that could never say yes.** `validateResponse` was:
+
+```js
+if (!data[subKey] || data[subKey] === 0) return false
+```
+
+which returns `false` or `undefined`, and never `true`. Its only caller compensated by
+testing `=== false`, so the app worked by accident: written the obvious way,
+`if (!validateResponse(...))`, it rejected every city that *was* found. The `=== 0` clause
+was dead too, since `!data[subKey]` already catches `0`. It returns a real boolean now.
+
+**Third-party text went into `innerHTML` unescaped.** `src/client/js/UI/markup.js` builds
+HTML from geonames, weatherbit and pixabay values and assigns it to `innerHTML`, with the
+attributes single-quoted. Measured: a `previewURL` of `x' onerror='alert(1)` produces
+
+```text
+<img src='x' onerror='alert(1)' alt='...' />
+```
+
+a live `onerror` handler. This is not only an injection question: real place names break it
+too, because `L'Aquila`, `Val-d'Or` and `Martha's Vineyard` all contain an apostrophe that
+ends the attribute. Values are escaped now, attributes are double-quoted, and URLs go through
+a check that rejects any scheme other than `http`/`https`, since escaping does nothing about
+`javascript:alert(1)`.
+
+**The client could only ever talk to localhost.** `handlers/index.js` posted to
+`http://localhost:8085/api/travels`, hardcoded, so a built bundle deployed anywhere could not
+reach its own server. It posts to `/api/travels` now, which works in development and wherever
+it is served from. That absolute URL is also what forced the next item.
+
+**CORS was open to the entire internet.** `app.use(cors())` with no arguments sends
+`Access-Control-Allow-Origin: *`. On a server whose only job is holding three API keys, that
+means any page anywhere could spend the quota. It now allows only the origins named in
+`CORS_ORIGIN`, and with none set it allows nothing cross-origin, which is all the bundled
+client needs.
+
+**Smaller things.**
+
+- `app.js` called `path.resolve` without importing `path`, so `GET /` threw a `ReferenceError`
+  whenever `NODE_ENV` was not `production`, which is to say under `npm run dev`.
+- geonames was called over plain `http://`, putting the credential in the query string on the
+  wire in clear text. It uses `https://secure.geonames.org/` now.
+- `addMarkup` set `selectedElement.getElementsByClassName.display = 'none'` and back to
+  `'block'`. `getElementsByClassName` is a method, so both lines set a property on a function
+  object and did nothing; only the `removeChild` between them had any effect.
+- The forecast printed `tempDate.getMonth()`, which is zero-based, so March showed as `2`.
+- The port was hardcoded, and `server.on('error')` was missing, so an occupied port produced
+  an unhandled event rather than a message.
+- `webpack`, `webpack-cli` and `concurrently` were in `dependencies` rather than
+  `devDependencies`, so a production install pulled the build toolchain.
+- `.gitignore` gained logs, keys, `credentials*`, `secrets/` and local databases. The README
+  pointed at `.env-sample`; the file is `.env-example`.
+
+## Tests
+
+There were none. `jest` was configured, `jest.setup.js` existed and `src/fixtures/index.js`
+held fixture data, but the repository contained zero test files. Worse, `jest.config.js`
+named `jest-html-reporter` in its `reporters` block, and that package is in **neither**
+`package.json` nor `package-lock.json`. Jest resolves reporters before running anything, so
+`npm test` could not start at all.
+
+There are **51 tests** now, over six suites, covering every fix above. Each one was
+poison-tested: the fix was reverted and the suite checked to go red, so none of them passes
+vacuously.
+
+| reintroduced bug | tests that fail |
+| --- | --- |
+| stray digit in the latitude | 1 |
+| `current/daily` instead of `current` | 1 |
+| `validateResponse` returning `undefined` | 9 |
+| removing the Express error middleware | 6 |
+| unescaped HTML | 3 |
+| allowing any URL scheme in `src` | 2 |
+| parser throwing on an empty response | 4 |
+
+Three things about the setup are worth knowing before adding tests, because each cost time:
+
+- `jest.mock(path)` with no factory does not work here. `jest-esm-transformer` compiles
+  `export { a, b }` into read-only getters, so automocking yields plain values and
+  `someExport.mockResolvedValue` is not a function.
+- `jest.mock` calls are **not hoisted** above `import` statements, because
+  `jest-esm-transformer` does not run `babel-plugin-jest-hoist`. `import app from '../app'`
+  at the top of a file loads the real modules before the mocks apply. Measured: the route
+  answered `404` for every case while `geoGetCityInfo.mock.calls.length` was `0`. Use
+  `require` after the `jest.mock` calls.
+- The API modules read their keys into module-level constants at import time, so a test must
+  set `process.env.*` *before* requiring them. Otherwise the property check fails and the
+  function returns before calling `fetch`, which is also what the app does in production when
+  a key is missing.
+
+Lint is clean now too; it was not. `npx eslint src` reported 3 errors on `master`.
+
+## Running it
+
+Three API keys are needed, all free:
+
+1. [Geonames](http://www.geonames.org/export/web-services.html) — a username, not a key
+2. [Weatherbit](https://www.weatherbit.io/account/create)
+3. [Pixabay](https://pixabay.com/api/docs/)
+
+Copy `.env-example` to `.env` and fill in the three values. `.env` is gitignored.
+
+```shell
 npm install
-```
 
-## Development
-
-### Start dev server
-
-```
-npm run dev:start
-```
-
-### Start dev builder (aka, webpack-dev-server) or dev application
-
-```
-npm run dev:build
-```
-
-## Production
-
-### Build production application
-
-```
-npm run prod:build
-```
-
-### Start production server
-
-```
-npm run prod:start
-```
-
-### Run Unit tests
-
-```
-npm run test
-```
-
-### Lint project
-
-```
+npm run dev            # webpack-dev-server plus the API server
+npm test               # 51 tests
 npm run lint
 ```
+
+For production:
+
+```shell
+npm run prod:build
+npm run prod:start     # PORT is honoured, defaulting to 8085
+```
+
+Optionally, if the bundle is served from a different origin than the API:
+
+```shell
+CORS_ORIGIN=https://your-site.example npm run prod:start
+```
+
+### Node 14 to 20. Not 22 or newer.
+
+Two separate era limits, both measured rather than assumed.
+
+**The build** needs a flag on Node 17+. Webpack 4 uses an MD4 hash that OpenSSL 3 removed, so
+`npm run prod:build` fails with `ERR_OSSL_EVP_UNSUPPORTED`:
+
+```shell
+NODE_OPTIONS=--openssl-legacy-provider npm run prod:build
+```
+
+**The server has a hard ceiling.** These files use `import`/`export` in `.js` with no
+`"type": "module"`, so they run through `-r esm`, and the `esm` package was last published in
+2020. Measured, starting the server and requesting `GET /` and `POST /api/travels`:
+
+| Node | result |
+| --- | --- |
+| 14, 16, 18, 20 | `Server listening`, `GET /` → **200**, `POST /api/travels {}` → **400** |
+| 22, 24 | fails at startup inside `esm.js`: `TypeError: Function.prototype.apply was called on undefined` |
+
+That is a dependency limit, not a code one, and the dependencies here are deliberately left
+at their 2021 versions. Use Node 20 or below to run it; the tests themselves run on any
+version, since jest does not go through `esm`.
+
+## Not covered
+
+- **No live API calls are exercised.** Every test mocks `node-fetch` or the API modules, so
+  the URL construction and response handling are verified but the three services were never
+  actually called. That would need real keys.
+- **Dependencies are unchanged.** `webpack` 4, `jest` 26, `node-sass` 4 and `esm` 3 all stay
+  where they were. The known advisories against them are left in place on purpose; upgrading
+  would make this a different project rather than a fixed one.
+- **`node-sass` 4.14.1 fails its own postinstall on some toolchains, and did so before this
+  change.** Measured on `node:14-alpine` with python3/make/g++ installed: `npm ci` exits 1 at
+  `node-sass@4.14.1 postinstall: node scripts/build.js`, and it does so identically on
+  `master`, so it is not something introduced here. `npm ci --ignore-scripts` succeeds on both,
+  installing the same 2060 packages. node-sass is a devDependency needed only to compile
+  `.scss`, so the tests and the server run without it; the production build does not.
+- **The service worker is unexamined.** `workbox-webpack-plugin` emits one and nothing here
+  tests what it caches.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ named `jest-html-reporter` in its `reporters` block, and that package is in **ne
 `package.json` nor `package-lock.json`. Jest resolves reporters before running anything, so
 `npm test` could not start at all.
 
-There are **63 tests** now, over seven suites, covering every fix above. Each one was
+There are **64 tests** now, over seven suites, covering every fix above. Each one was
 poison-tested: the fix was reverted and the suite checked to go red, so none of them passes
 vacuously.
 
@@ -129,11 +129,16 @@ vacuously.
 | `current/daily` instead of `current` | 1 |
 | `validateResponse` returning `undefined` | 9 |
 | removing the Express error middleware | 6 |
-| `escapeHTML` removed from the `<h2>` | 1 |
-| `safeURL` removed from the photo `src` | 2 |
-| `escapeHTML` removed from the weather description | 1 |
-| the forecast icon allowlist removed | 1 |
-| `escapeHTML` removed from the days warning | 1 |
+| `escapeHTML` off the `<h2>` city name | 1 |
+| `safeURL` off the photo `src` | 2 |
+| `escapeHTML` off the photo `alt` | 2 |
+| the **current-weather** icon allowlist off | 1 |
+| `escapeHTML` off the current-weather `alt` | 2 |
+| `escapeHTML` off the weather description | 1 |
+| the **forecast** icon allowlist off | 1 |
+| `escapeHTML` off the forecast `alt` | 1 |
+| `escapeHTML` off the days warning | 1 |
+| the empty-photos guard off | 1 |
 | allowing any URL scheme in `safeURL` | 2 |
 | parser throwing on an empty response | 4 |
 
@@ -143,11 +148,23 @@ then removed `escapeHTML` from the `<h2>` and all tests still passed, because no
 exercised `markup.js` itself. `markup.test.js` closes that by running `generateMarkup` and
 inspecting the parsed DOM for inline event handlers and injected elements.
 
-Getting that test right needed two payloads, and the first version of it was worthless with
-one. A single-quote payload cannot break out of a double-quoted attribute, so with only
-`x' onerror='...` the suite stayed green through four separate sink regressions. It now uses
-`x" onerror="...` for attribute contexts and `<img src=x onerror="...">` for element content,
-and every sink regression is caught.
+Getting that test right took three passes, and the first two looked finished while guarding
+almost nothing. Both failures are worth stating because they generalise:
+
+**The payload has to match the context.** A single-quote payload cannot break out of a
+double-quoted attribute, so with only `x' onerror='...` the suite stayed green through four
+separate sink regressions. It now uses `x" onerror="...` for attribute contexts and
+`<img src=x onerror="...">` for element content.
+
+**A guard that short-circuits hides every guard behind it.** Two sinks were still unguarded
+after that. The icon allowlist drops the whole `<img>` when the icon is hostile, so an `alt`
+beside a hostile icon never renders at all and removing its escaping is invisible. Reaching
+those `alt` attributes needs a *valid* icon with a hostile description. Likewise, feeding the
+hostile icon only to `forecastMin` left the current-weather allowlist untested, since
+`currentMin.icon` only ever saw `c02d`.
+
+All ten guarded values in `markup.js` are now poison-tested individually, and each one fails
+on its own.
 
 One poison deliberately does *not* fail: reverting the attributes to single quotes while
 keeping `escapeHTML`. That is correct rather than a gap, since `escapeHTML` escapes both `'`

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ named `jest-html-reporter` in its `reporters` block, and that package is in **ne
 `package.json` nor `package-lock.json`. Jest resolves reporters before running anything, so
 `npm test` could not start at all.
 
-There are **85 tests** now, over eight suites, covering every fix above. Each one was
+There are **109 tests** now, over nine suites, covering every fix above. Each one was
 poison-tested: the fix was reverted and the suite checked to go red, so none of them passes
 vacuously.
 
@@ -215,9 +215,34 @@ Three things about the setup are worth knowing before adding tests, because each
 
 Lint is clean now too; it was not. `npx eslint src` reported 3 errors on `master`.
 
+### API keys were being written to the logs
+
+`node-fetch@2.6.1` puts the full request URL into its error messages, and every URL this project
+builds carries a credential in the query string. Measured on the pinned version:
+
+```text
+request to https://…/x?key=SUPERSECRETKEY123 failed, reason: getaddrinfo ENOTFOUND …
+invalid json response body at https://…/?key=SUPERSECRETKEY123 reason: Unexpected token …
+```
+
+All four log boundaries interpolated the error, so every network failure and every non-JSON
+response wrote an API key to the log. Three of those log lines were original; the fourth was
+mine, and it was the worst of them, because `err.stack` includes the message.
+
+Errors now go through `describeError`, which emits only the operation name, the error's `name`,
+and its `code` or `type`:
+
+```text
+geoGetCityInfo: FetchError (code: ENOTFOUND)
+```
+
+Tested from both ends: `describeError` against six error shapes including a thrown string and
+`null`, and end-to-end through the real modules, asserting that nothing written to `console` and
+nothing in the HTTP response contains `http`, `key=` or `username=`.
+
 ## Running it
 
-Three API keys are needed, all free:
+Three API credentials are needed, all free. Note that geonames issues a **username**, not a key:
 
 1. [Geonames](https://www.geonames.org/export/web-services.html) — a username, not a key
 2. [Weatherbit](https://www.weatherbit.io/account/create)
@@ -229,7 +254,7 @@ Copy `.env-example` to `.env` and fill in the three values. `.env` is gitignored
 npm install
 
 npm run dev            # webpack-dev-server plus the API server
-npm test               # 51 tests
+npm test               # 109 tests
 npm run lint
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ named `jest-html-reporter` in its `reporters` block, and that package is in **ne
 `package.json` nor `package-lock.json`. Jest resolves reporters before running anything, so
 `npm test` could not start at all.
 
-There are **84 tests** now, over eight suites, covering every fix above. Each one was
+There are **85 tests** now, over eight suites, covering every fix above. Each one was
 poison-tested: the fix was reverted and the suite checked to go red, so none of them passes
 vacuously.
 
@@ -167,6 +167,28 @@ hostile icon only to `forecastMin` left the current-weather allowlist untested, 
 `|| {}` that no test could exercise, because its only caller passes an already-normalised
 object and it is not exported. Reverting that guard left all 84 tests green, which is the
 signature of dead code rather than of a coverage gap. It was removed rather than tested.
+
+**A test can also be disabled by its environment.** The forecast-date test asserts `3/15` to
+guard the switch from local to UTC getters, and in the UTC zone the two are identical by
+definition, so nothing can tell them apart. Measured: with the fix reverted, `TZ=UTC` passed
+all 84 tests while `TZ=America/New_York` failed one. The test only ever caught anything because
+this machine is `America/Los_Angeles`; a UTC CI runner, which is the default nearly everywhere,
+would have sailed through.
+
+`jest.config.js` therefore pins `process.env.TZ = 'America/New_York'`. Three things about that
+are worth stating, because each is a trap:
+
+- **Pinning UTC would be the intuitive choice and exactly wrong**, since it makes the test
+  permanently blind to the bug it exists to catch.
+- **It has to be in the config, not `jest.setup.js`.** Setting `process.env.TZ` from a setup
+  file is too late on Node 24 and has no effect: measured, the poisoned fix still passed 84/84
+  under `TZ=UTC` with the setup file pinning New York.
+- **The pin itself is guarded**, by a test asserting the process is in a non-UTC zone.
+  Otherwise removing the pin would silently disable the timezone test rather than break
+  anything. Verified: changing the pin to `UTC` fails that guard.
+
+With the pin in place the poisoned fix is caught under every host zone tried: `UTC`,
+`America/Los_Angeles`, `Asia/Tokyo` and `Europe/London`.
 
 All ten guarded values in `markup.js` are now poison-tested individually, and each one fails
 on its own.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,18 @@ the request URL, and it had two bugs:
 `${baseURL}${api}/daily?key=${apiKey}&lat=${lat}6&lon=${lng}`
 ```
 
-The `6` after `${lat}` appended a digit to every latitude. Measured: a latitude of `40.7128`
-was sent as `lat=40.71286`. Nothing errored, the API simply answered about somewhere else,
-and how far off depended on how many decimal places the coordinate happened to have.
+The `6` after `${lat}` appended a digit to every latitude, and how bad that is depends
+inversely on precision, so the high-precision example is the least alarming one:
+
+| latitude | sent as | shift |
+| --- | --- | --- |
+| `40.7128` | `40.71286` | 0.0001°, about 11 m |
+| `51.5` | `51.56` | 0.06°, about 6.7 km |
+| `4` | `46` | 42°, about 4,700 km |
+| `0` | `6` | 6° |
+
+geonames returns whatever precision it holds for a place, so a low-precision latitude asked
+about a different continent. Nothing errored in any case.
 
 `${api}/daily` was also only right for one of its two callers. Per Weatherbit's
 documentation the current-conditions endpoint is `/v2.0/current` and **there is no
@@ -110,7 +119,7 @@ named `jest-html-reporter` in its `reporters` block, and that package is in **ne
 `package.json` nor `package-lock.json`. Jest resolves reporters before running anything, so
 `npm test` could not start at all.
 
-There are **51 tests** now, over six suites, covering every fix above. Each one was
+There are **63 tests** now, over seven suites, covering every fix above. Each one was
 poison-tested: the fix was reverted and the suite checked to go red, so none of them passes
 vacuously.
 
@@ -120,9 +129,30 @@ vacuously.
 | `current/daily` instead of `current` | 1 |
 | `validateResponse` returning `undefined` | 9 |
 | removing the Express error middleware | 6 |
-| unescaped HTML | 3 |
-| allowing any URL scheme in `src` | 2 |
+| `escapeHTML` removed from the `<h2>` | 1 |
+| `safeURL` removed from the photo `src` | 2 |
+| `escapeHTML` removed from the weather description | 1 |
+| the forecast icon allowlist removed | 1 |
+| `escapeHTML` removed from the days warning | 1 |
+| allowing any URL scheme in `safeURL` | 2 |
 | parser throwing on an empty response | 4 |
+
+**The escaping helpers and their application are tested separately, because passing one does
+not imply the other.** `escape.test.js` proves `escapeHTML` and `safeURL` behave; a reviewer
+then removed `escapeHTML` from the `<h2>` and all tests still passed, because nothing
+exercised `markup.js` itself. `markup.test.js` closes that by running `generateMarkup` and
+inspecting the parsed DOM for inline event handlers and injected elements.
+
+Getting that test right needed two payloads, and the first version of it was worthless with
+one. A single-quote payload cannot break out of a double-quoted attribute, so with only
+`x' onerror='...` the suite stayed green through four separate sink regressions. It now uses
+`x" onerror="...` for attribute contexts and `<img src=x onerror="...">` for element content,
+and every sink regression is caught.
+
+One poison deliberately does *not* fail: reverting the attributes to single quotes while
+keeping `escapeHTML`. That is correct rather than a gap, since `escapeHTML` escapes both `'`
+and `"`, so either quoting style is safe once the value is escaped. The double quotes are
+defence in depth, not the fix.
 
 Three things about the setup are worth knowing before adding tests, because each cost time:
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,14 +1,12 @@
 module.exports = {
   transform: {
-    "\\.m?jsx?$": "jest-esm-transformer"
+    '\\.m?jsx?$': 'jest-esm-transformer'
   },
-  // setupTestFrameworkScriptFile has been deprecated in
-  // favor of setupFilesAfterEnv in jest 24
+  // setupFilesAfterEnv, not the setupTestFrameworkScriptFile deprecated in jest 24.
   setupFilesAfterEnv: ['./jest.setup.js'],
-  reporters: [
-    'default',
-    ['./node_modules/jest-html-reporter', {
-        pageTitle: 'Test Report'
-    }]
-]
-};
+  testEnvironment: 'node'
+  // The `reporters` block used to name jest-html-reporter, which appears in neither
+  // package.json nor package-lock.json. Jest resolves reporters before running anything, so
+  // `npm test` could not start at all: it failed on the missing module. Removed rather than
+  // adding a dependency, since the default reporter is what this project needs.
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,21 @@
+// Pinned to a NON-UTC zone, and that is the whole point.
+//
+// markup.js formats a date-only string with getUTCMonth()/getUTCDate(). The bug it replaced
+// used the local getters, and `new Date('2021-03-15')` is parsed as UTC midnight, so the local
+// getters report 14 March anywhere west of UTC. In the UTC zone the local and UTC getters agree
+// by definition, so no assertion can tell the two implementations apart: reverting the fix
+// passed all 84 tests under TZ=UTC and failed only because this machine happens to be
+// America/Los_Angeles. A UTC CI runner, which is the default nearly everywhere, would never
+// have caught it.
+//
+// So pinning UTC here would be the intuitive choice and exactly wrong: it would make the
+// timezone test permanently blind to the bug it exists to catch.
+//
+// This must live in the config, not in setupFilesAfterEach. Setting process.env.TZ from
+// jest.setup.js is too late on Node 24 and has no effect: measured, the poisoned fix still
+// passed 84/84 under TZ=UTC with the setup file pinning New York.
+process.env.TZ = 'America/New_York'
+
 module.exports = {
   transform: {
     '\\.m?jsx?$': 'jest-esm-transformer'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "api-of-apis",
+  "name": "travel-app",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "description": "One request fanned out to three public APIs (geonames, weatherbit, pixabay), composed server-side so the keys never reach the browser.",
+  "description": "One request fanned out to three public APIs (geonames, weatherbit, pixabay), composed server-side so the keys never reach the browser. Package name left as travel-app to match package-lock.json: renaming it would require regenerating the lockfile, which re-resolves the ^ ranges and upgrades 17 transitive packages.",
   "dependencies": {
     "@babel/runtime": "^7.14.0",
     "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "travel-app",
+  "name": "api-of-apis",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
@@ -15,18 +15,15 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "description": "",
+  "description": "One request fanned out to three public APIs (geonames, weatherbit, pixabay), composed server-side so the keys never reach the browser.",
   "dependencies": {
     "@babel/runtime": "^7.14.0",
     "body-parser": "^1.19.0",
-    "concurrently": "^6.2.0",
     "cors": "^2.8.5",
     "dotenv": "^8.6.0",
     "esm": "^3.2.25",
     "express": "^4.17.1",
-    "node-fetch": "^2.6.1",
-    "webpack": "^4.35.3",
-    "webpack-cli": "^3.3.5"
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",
@@ -34,6 +31,7 @@
     "@babel/preset-env": "^7.14.2",
     "babel-loader": "^8.2.2",
     "clean-webpack-plugin": "^3.0.0",
+    "concurrently": "^6.2.0",
     "css-loader": "^5.2.6",
     "eslint": "^7.27.0",
     "eslint-config-prettier": "^8.3.0",
@@ -53,6 +51,8 @@
     "style-loader": "^2.0.0",
     "supertest": "^6.1.3",
     "terser-webpack-plugin": "^4.2.3",
+    "webpack": "^4.35.3",
+    "webpack-cli": "^3.3.5",
     "webpack-dev-server": "^3.7.2",
     "workbox-webpack-plugin": "^6.1.0"
   }

--- a/src/client/js/UI/escape.js
+++ b/src/client/js/UI/escape.js
@@ -1,0 +1,38 @@
+// Values interpolated into markup here come from three third-party APIs (geonames,
+// weatherbit, pixabay) and land in `innerHTML`. None of it was escaped, and the
+// attributes were single-quoted, so a value containing an apostrophe broke out of the
+// attribute. That is not hypothetical for place names: L'Aquila, Val-d'Or and Martha's
+// Vineyard all do it, and a `previewURL` of  x' onerror='alert(1)  yields a live
+// onerror handler.
+//
+// So: escape everything interpolated, and use double quotes for attributes.
+
+const escapeHTML = (value) => {
+  if (value === null || value === undefined) return ''
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+// Escaping alone does not make a URL safe to put in src: `javascript:alert(1)` contains
+// no character that escaping touches. Only http(s) is allowed through, and anything else
+// becomes an empty string so the image simply fails to load.
+const safeURL = (value) => {
+  if (value === null || value === undefined) return ''
+  const raw = String(value).trim()
+  try {
+    const parsed = new URL(raw)
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return ''
+    return escapeHTML(parsed.href)
+  } catch (err) {
+    // Not an absolute URL. Relative paths are fine, but reject anything carrying a
+    // scheme-ish prefix or a quote that could terminate the attribute.
+    if (/^[a-z][a-z0-9+.-]*:/i.test(raw)) return ''
+    return escapeHTML(raw)
+  }
+}
+
+export { escapeHTML, safeURL }

--- a/src/client/js/UI/markup.js
+++ b/src/client/js/UI/markup.js
@@ -1,4 +1,5 @@
 import { generateRandomNumber } from '../utils/index'
+import { escapeHTML, safeURL } from './escape'
 
 const generateMarkup = (element = {}, data = {}) => {
   const { type, id, classes } = element
@@ -16,31 +17,49 @@ const generateMarkup = (element = {}, data = {}) => {
 }
 
 const markupCity = (data = {}) => {
-  return `<h2>${data.name}</h2>`
+  return `<h2>${escapeHTML(data.name)}</h2>`
 }
 
 const markupPhotos = (data = [], altForPhoto = '') => {
+  // An empty photos array made generateRandomNumber(0) index undefined and this threw
+  // on `.previewURL`. Pixabay legitimately returns no hits for an obscure query.
+  if (!Array.isArray(data) || data.length === 0) return ''
   const randomIndex = generateRandomNumber(data.length)
-  const selectedElement = data[randomIndex]
-  return `<img src='${selectedElement.previewURL}' alt='${altForPhoto}' />`
+  const selectedElement = data[randomIndex] || {}
+  return `<img src="${safeURL(selectedElement.previewURL)}" alt="${escapeHTML(altForPhoto)}" />`
 }
 
 const markupWeather = (data = {}, altForPhoto = '') => {
+  // The icon code is pasted into a URL path, so it is restricted to the shape weatherbit
+  // actually uses (letters and digits, e.g. c02d). Anything else would let a compromised
+  // or unexpected response steer the path.
+  const icon = /^[a-z0-9]{1,8}$/i.test(String(data.icon || '')) ? data.icon : ''
+  const iconTag = icon
+    ? `<img src="https://www.weatherbit.io/static/img/icons/${icon}.png" alt="${escapeHTML(altForPhoto)}" />`
+    : ''
   return `
     <div class="container">
-      <img src='https://www.weatherbit.io/static/img/icons/${data.icon}.png' alt='${altForPhoto}' />
-      <span>Current weather: ${data.description}</span>
+      ${iconTag}
+      <span>Current weather: ${escapeHTML(data.description)}</span>
     </div>
   `
 }
 
 const markupWeatherForecast = (forecast = []) => {
   let markup = '<div class="travel-forecast">'
-  for (let element of forecast) {
+  for (let element of Array.isArray(forecast) ? forecast : []) {
     const tempDate = new Date(element.date)
     markup += `<div class="flex-item">`
-    markup += `<div>${tempDate.getMonth()}/${tempDate.getDate()}</div>`
-    markup += `<img src='https://www.weatherbit.io/static/img/icons/${element.weather.icon}.png' alt='${element.weather.description}' />`
+    markup += `<div>${tempDate.getMonth() + 1}/${tempDate.getDate()}</div>`
+    const weather = element.weather || {}
+    // No optional chaining: .eslintrc.js pins ecmaVersion to 2018, which predates it, and
+    // this project's era is 2021 rather than whatever the current syntax allows.
+    const icon = /^[a-z0-9]{1,8}$/i.test(String(weather.icon || '')) ? weather.icon : ''
+    if (icon) {
+      markup += `<img src="https://www.weatherbit.io/static/img/icons/${icon}.png" alt="${escapeHTML(
+        weather.description
+      )}" />`
+    }
     markup += `</div>`
   }
   markup += '</div>'
@@ -57,7 +76,7 @@ const markupInfoWrapper = (city, photos, weather) => {
   markup += `</div>`
   markup += `</div>`
   markup += `<h3>Forecast</h3>`
-  markup += `${weather.days.warning ? weather.days.warning : ''}`
+  markup += `${weather.days && weather.days.warning ? escapeHTML(weather.days.warning) : ''}`
   markup += `${markupWeatherForecast(weather.forecastMin)}`
   return markup
 }
@@ -70,9 +89,11 @@ const addMarkup = (element = {}, markup = '', childElement = {}) => {
 
   const selectedElement = document.querySelector(`${elementType}${elementText}`)
   if (childElementToremove) {
-    selectedElement.getElementsByClassName.display = 'none'
+    // Was `selectedElement.getElementsByClassName.display = 'none'` and back to 'block'.
+    // getElementsByClassName is a METHOD, so those two lines set a property on a function
+    // object and did nothing at all. The removeChild between them is the only part that
+    // ever had an effect, so the wrapper is gone rather than corrected.
     selectedElement.removeChild(childElementToremove)
-    selectedElement.getElementsByClassName.display = 'block'
   }
 
   document.querySelector(`${elementType}${elementText}`).appendChild(markup)

--- a/src/client/js/UI/markup.js
+++ b/src/client/js/UI/markup.js
@@ -8,7 +8,16 @@ const generateMarkup = (element = {}, data = {}) => {
   newElement.setAttribute('id', id)
   newElement.classList.add(...classes)
 
-  const { city, photos, weather } = data
+  // Normalised, not defaulted. A default parameter applies to `undefined` only, so `null`
+  // passed straight through and `data.icon` threw
+  // `TypeError: Cannot read properties of null`. That is not hypothetical: the route returns
+  // whatever parsedWeatherGetCity produced, and its documented fallback for a weatherbit
+  // response with no current data is `currentMin: null`. So an otherwise successful travel
+  // response could stop the client rendering.
+  const safe = data || {}
+  const city = safe.city || {}
+  const photos = Array.isArray(safe.photos) ? safe.photos : []
+  const weather = safe.weather || {}
 
   let markup = markupInfoWrapper(city, photos, weather)
 
@@ -16,6 +25,10 @@ const generateMarkup = (element = {}, data = {}) => {
   return newElement
 }
 
+// No `|| {}` here on purpose. markupCity is not exported and its only caller passes the
+// already-normalised `city` from markupInfoWrapper, so a null can never reach it. Adding a
+// guard produced a branch no test could reach: reverting it left all 84 tests green, which is
+// the signature of dead defence rather than defence in depth.
 const markupCity = (data = {}) => {
   return `<h2>${escapeHTML(data.name)}</h2>`
 }
@@ -29,7 +42,8 @@ const markupPhotos = (data = [], altForPhoto = '') => {
   return `<img src="${safeURL(selectedElement.previewURL)}" alt="${escapeHTML(altForPhoto)}" />`
 }
 
-const markupWeather = (data = {}, altForPhoto = '') => {
+const markupWeather = (rawData = {}, altForPhoto = '') => {
+  const data = rawData || {}
   // The icon code is pasted into a URL path, so it is restricted to the shape weatherbit
   // actually uses (letters and digits, e.g. c02d). Anything else would let a compromised
   // or unexpected response steer the path.
@@ -50,7 +64,10 @@ const markupWeatherForecast = (forecast = []) => {
   for (let element of Array.isArray(forecast) ? forecast : []) {
     const tempDate = new Date(element.date)
     markup += `<div class="flex-item">`
-    markup += `<div>${tempDate.getMonth() + 1}/${tempDate.getDate()}</div>`
+    // UTC getters. `new Date('2021-03-15')` is parsed as UTC midnight, and the local getters
+    // then report 14 March anywhere west of UTC. The original used getMonth(), which was also
+    // zero-based, so this line was wrong twice: it showed 2/15 in UTC and 2/14 in New York.
+    markup += `<div>${tempDate.getUTCMonth() + 1}/${tempDate.getUTCDate()}</div>`
     const weather = element.weather || {}
     // No optional chaining: .eslintrc.js pins ecmaVersion to 2018, which predates it, and
     // this project's era is 2021 rather than whatever the current syntax allows.

--- a/src/client/js/UI/markup.js
+++ b/src/client/js/UI/markup.js
@@ -62,7 +62,17 @@ const markupWeather = (rawData = {}, altForPhoto = '') => {
 const markupWeatherForecast = (forecast = []) => {
   let markup = '<div class="travel-forecast">'
   for (let element of Array.isArray(forecast) ? forecast : []) {
-    const tempDate = new Date(element.date)
+    // A forecast object can arrive with a missing or unparseable datetime. The server parser
+    // filters null and primitive ENTRIES but does not inspect the date inside a valid object,
+    // so this loop used to render NaN/NaN.
+    // The date must be a non-empty string BEFORE constructing a Date, because new Date(null)
+    // is 1 January 1970 rather than an Invalid Date, and new Date(0) is too. Checking only
+    // getTime() for NaN let a null datetime render as 1/1. Measured:
+    //   new Date(null) -> 1970-01-01   new Date('') -> Invalid   new Date(0) -> 1970-01-01
+    const rawDate = element && element.date
+    if (typeof rawDate !== 'string' || rawDate.trim() === '') continue
+    const tempDate = new Date(rawDate)
+    if (Number.isNaN(tempDate.getTime())) continue
     markup += `<div class="flex-item">`
     // UTC getters. `new Date('2021-03-15')` is parsed as UTC midnight, and the local getters
     // then report 14 March anywhere west of UTC. The original used getMonth(), which was also

--- a/src/client/js/__tests__/escape.test.js
+++ b/src/client/js/__tests__/escape.test.js
@@ -1,0 +1,58 @@
+import { escapeHTML, safeURL } from '../UI/escape'
+
+// markup.js builds HTML from three third-party APIs and assigns it to innerHTML. Nothing
+// was escaped and the attributes were single-quoted, so an apostrophe broke out of the
+// attribute. These are the exact payloads used to demonstrate that.
+describe('escapeHTML', () => {
+  it('neutralises the characters that break out of markup', () => {
+    expect(escapeHTML('<img src=x onerror=alert(1)>')).toBe('&lt;img src=x onerror=alert(1)&gt;')
+    expect(escapeHTML("x' onerror='alert(1)")).toBe('x&#39; onerror=&#39;alert(1)')
+    expect(escapeHTML('a"b')).toBe('a&quot;b')
+    expect(escapeHTML('a&b')).toBe('a&amp;b')
+  })
+
+  it('handles a real place name with an apostrophe', () => {
+    // Not a hypothetical attack: L'Aquila, Val-d'Or and Martha's Vineyard all broke the
+    // alt attribute before.
+    expect(escapeHTML("L'Aquila")).toBe('L&#39;Aquila')
+  })
+
+  it('escapes the ampersand first, so escaping is not doubled', () => {
+    expect(escapeHTML('&lt;')).toBe('&amp;lt;')
+  })
+
+  it('returns an empty string for null and undefined rather than printing them', () => {
+    expect(escapeHTML(null)).toBe('')
+    expect(escapeHTML(undefined)).toBe('')
+  })
+})
+
+describe('safeURL', () => {
+  it('passes http and https through', () => {
+    expect(safeURL('https://pixabay.com/get/a.jpg')).toBe('https://pixabay.com/get/a.jpg')
+    expect(safeURL('http://pixabay.com/get/a.jpg')).toBe('http://pixabay.com/get/a.jpg')
+  })
+
+  it('rejects schemes that execute, which escaping alone would not catch', () => {
+    expect(safeURL('javascript:alert(1)')).toBe('')
+    expect(safeURL('data:text/html,<script>alert(1)</script>')).toBe('')
+    expect(safeURL('vbscript:msgbox(1)')).toBe('')
+  })
+
+  it('rejects a scheme hidden behind whitespace or case', () => {
+    expect(safeURL('  JavaScript:alert(1)')).toBe('')
+  })
+
+  it('escapes quotes in an otherwise valid URL so it cannot end the attribute', () => {
+    expect(safeURL("https://x.com/a.jpg' onerror='alert(1)")).not.toContain("'")
+  })
+
+  it('allows a relative path', () => {
+    expect(safeURL('/images/a.jpg')).toBe('/images/a.jpg')
+  })
+
+  it('returns empty for null and undefined', () => {
+    expect(safeURL(null)).toBe('')
+    expect(safeURL(undefined)).toBe('')
+  })
+})

--- a/src/client/js/__tests__/markup.test.js
+++ b/src/client/js/__tests__/markup.test.js
@@ -166,6 +166,51 @@ describe('generateMarkup escapes every sink', () => {
     noHandlers(node)
   })
 
+  // The route's own documented fallback for a weatherbit response with no current data is
+  // currentMin: null, and route.test.js's happy-path fixture returns exactly that. A default
+  // parameter only fires for undefined, so null reached data.icon and threw
+  // TypeError: Cannot read properties of null.
+  it.each([
+    ['currentMin null', { days: { days: 2 }, currentMin: null, forecastMin: [] }],
+    ['weather null', null],
+    ['forecastMin null', { days: { days: 2 }, currentMin: { icon: 'c02d' }, forecastMin: null }],
+    ['days null', { days: null, currentMin: { icon: 'c02d' }, forecastMin: [] }]
+  ])('renders with %s instead of throwing', (_label, weather) => {
+    expect(() => generateMarkup(element, data({ weather }))).not.toThrow()
+  })
+
+  // generateMarkup itself, not just its sections. The `|| {}` on the whole payload guards the
+  // case where the fetch resolved to null or the response had no body; nothing exercised it,
+  // so reverting it to a bare `const safe = data` left all 80 tests green.
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'nope'],
+    ['a number', 0]
+  ])('renders with a payload of %s instead of throwing', (_label, payload) => {
+    expect(() => generateMarkup(element, payload)).not.toThrow()
+  })
+
+  it('renders with a null city and null photos', () => {
+    expect(() => generateMarkup(element, data({ city: null, photos: null }))).not.toThrow()
+  })
+
+  // new Date('2021-03-15') is UTC midnight, so the local getters report 14 March anywhere
+  // west of UTC. The date shown must not depend on the reader's time zone.
+  it('shows the forecast date in UTC, not the local shift', () => {
+    const node = generateMarkup(
+      element,
+      data({
+        weather: {
+          days: { days: 1 },
+          currentMin: { icon: 'c02d', description: 'ok' },
+          forecastMin: [{ date: '2021-03-15', temp: 10, weather: { icon: 'c04d', description: 'ok' } }]
+        }
+      })
+    )
+    expect(node.querySelector('.travel-forecast .flex-item div').textContent).toBe('3/15')
+  })
+
   it('survives an empty photos array, which pixabay returns for obscure queries', () => {
     const node = generateMarkup(element, data({ photos: [] }))
     expect(node.querySelectorAll('.travel-image img').length).toBe(0)

--- a/src/client/js/__tests__/markup.test.js
+++ b/src/client/js/__tests__/markup.test.js
@@ -217,3 +217,14 @@ describe('generateMarkup escapes every sink', () => {
     noHandlers(node)
   })
 })
+
+// Guards the guard. The timezone test above can only fail in a non-UTC zone, so the pin in
+// jest.config.js is load-bearing. Without this, removing the pin would silently disable that
+// test rather than break anything, which is the same failure shape as a test whose payload
+// cannot escape its context.
+describe('the test environment itself', () => {
+  it('runs in a non-UTC timezone, or the UTC date test cannot fail', () => {
+    const offset = new Date('2021-03-15T00:00:00Z').getTimezoneOffset()
+    expect(offset).not.toBe(0)
+  })
+})

--- a/src/client/js/__tests__/markup.test.js
+++ b/src/client/js/__tests__/markup.test.js
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment jsdom
+ */
+import { generateMarkup } from '../UI/markup'
+
+// escape.test.js proves the helpers work. This file proves they are actually APPLIED at
+// every sink in markup.js, which is a separate question: a reviewer removed escapeHTML from
+// the <h2> and all 51 tests still passed, because nothing exercised markup.js itself.
+//
+// The assertions deliberately inspect the parsed DOM rather than the HTML string. If a value
+// escapes its attribute, the browser creates a real `onerror` attribute or a real element,
+// and querying for those catches it however the payload was shaped.
+
+// Two payloads, because the context decides what can escape it. A single-quote payload
+// cannot break out of a double-quoted attribute, so testing with one produces a test that
+// passes whether or not the escaping is there. Measured: with only a single-quote payload,
+// removing escapeHTML from the <h2> and from three other sinks left all tests green.
+//
+//   ATTR  breaks a double-quoted attribute, which is what markup.js now emits
+//   TEXT  creates a real element when interpolated into element content
+const ATTR = 'x" onerror="window.__pwned = true'
+const TEXT = '<img src=x onerror="window.__pwned = true">'
+
+const element = { type: 'div', id: 'results', classes: ['travel'] }
+
+const data = (overrides = {}) => ({
+  city: { name: 'London', lat: '51.5', lng: '-0.1' },
+  photos: [{ previewURL: 'https://pixabay.com/get/a.jpg', tags: 'city' }],
+  weather: {
+    days: { days: 2 },
+    currentMin: { icon: 'c02d', description: 'Scattered clouds' },
+    forecastMin: [{ date: '2021-03-15', temp: 10, weather: { icon: 'c04d', description: 'Overcast' } }]
+  },
+  ...overrides
+})
+
+const noHandlers = (node) => {
+  // No element anywhere may carry an inline event handler or be a script.
+  expect(node.querySelectorAll('script').length).toBe(0)
+  for (const el of node.querySelectorAll('*')) {
+    for (const attr of el.attributes) {
+      expect(attr.name.startsWith('on')).toBe(false)
+    }
+  }
+}
+
+describe('generateMarkup escapes every sink', () => {
+  afterEach(() => {
+    delete window.__pwned
+  })
+
+  // The city name reaches an element's text (the <h2>) AND two alt attributes, so it is
+  // tested with both payload shapes.
+  it.each([
+    ['attribute-breaking', ATTR],
+    ['element-creating', TEXT]
+  ])('escapes the city name against a %s payload', (_label, payload) => {
+    const node = generateMarkup(element, data({ city: { name: payload, lat: '1', lng: '2' } }))
+    noHandlers(node)
+    expect(node.textContent).toContain(payload)
+    expect(window.__pwned).toBeUndefined()
+  })
+
+  it('escapes a photo previewURL', () => {
+    const node = generateMarkup(element, data({ photos: [{ previewURL: ATTR, tags: 't' }] }))
+    noHandlers(node)
+    expect(window.__pwned).toBeUndefined()
+  })
+
+  it('rejects a javascript: previewURL rather than escaping it', () => {
+    const node = generateMarkup(element, data({ photos: [{ previewURL: 'javascript:alert(1)', tags: 't' }] }))
+    const img = node.querySelector('.travel-image img')
+    if (img) expect(img.getAttribute('src')).toBe('')
+    noHandlers(node)
+  })
+
+  it.each([
+    ['attribute-breaking', ATTR],
+    ['element-creating', TEXT]
+  ])('escapes the weather description against a %s payload', (_label, payload) => {
+    const node = generateMarkup(
+      element,
+      data({
+        weather: { ...data().weather, currentMin: { icon: 'c02d', description: payload } }
+      })
+    )
+    noHandlers(node)
+    expect(node.textContent).toContain(payload)
+    expect(window.__pwned).toBeUndefined()
+  })
+
+  it('escapes the forecast description and drops a hostile icon code', () => {
+    const node = generateMarkup(
+      element,
+      data({
+        weather: {
+          ...data().weather,
+          forecastMin: [{ date: '2021-03-15', temp: 10, weather: { icon: ATTR, description: ATTR } }]
+        }
+      })
+    )
+    noHandlers(node)
+    // The icon is allowlisted, not escaped, so a hostile code yields no img at all.
+    expect(node.querySelectorAll('.travel-forecast img').length).toBe(0)
+  })
+
+  // The warning is interpolated into element content, so TEXT is the payload that matters.
+  it.each([
+    ['attribute-breaking', ATTR],
+    ['element-creating', TEXT]
+  ])('escapes the days warning against a %s payload', (_label, payload) => {
+    const node = generateMarkup(
+      element,
+      data({
+        weather: { ...data().weather, days: { days: 20, warning: payload } }
+      })
+    )
+    noHandlers(node)
+    expect(node.textContent).toContain(payload)
+    expect(window.__pwned).toBeUndefined()
+  })
+
+  it('still renders the good case correctly', () => {
+    const node = generateMarkup(element, data())
+    expect(node.querySelector('h2').textContent).toBe('London')
+    expect(node.querySelector('.travel-image img').getAttribute('src')).toBe('https://pixabay.com/get/a.jpg')
+    expect(node.querySelectorAll('.travel-forecast img').length).toBe(1)
+    noHandlers(node)
+  })
+
+  it('renders an apostrophe place name intact, in text and in alt', () => {
+    const node = generateMarkup(element, data({ city: { name: "L'Aquila", lat: '1', lng: '2' } }))
+    expect(node.querySelector('h2').textContent).toBe("L'Aquila")
+    expect(node.querySelector('.travel-image img').getAttribute('alt')).toBe("L'Aquila")
+    noHandlers(node)
+  })
+
+  it('survives an empty photos array, which pixabay returns for obscure queries', () => {
+    const node = generateMarkup(element, data({ photos: [] }))
+    expect(node.querySelectorAll('.travel-image img').length).toBe(0)
+    noHandlers(node)
+  })
+})

--- a/src/client/js/__tests__/markup.test.js
+++ b/src/client/js/__tests__/markup.test.js
@@ -89,19 +89,27 @@ describe('generateMarkup escapes every sink', () => {
     expect(window.__pwned).toBeUndefined()
   })
 
-  it('escapes the forecast description and drops a hostile icon code', () => {
+  // Both icon sinks, not just the forecast one. markupWeather and markupWeatherForecast each
+  // build src="https://.../icons/${icon}.png" with the icon allowlisted rather than escaped,
+  // so the allowlist is that value's only protection. A reviewer removed the current-weather
+  // allowlist alone and all 63 tests stayed green, because this fixture only ever fed the
+  // hostile value to forecastMin[].weather.icon while currentMin.icon stayed 'c02d'. The DOM
+  // probe on that poison showed a real IMG[onerror] attribute being created.
+  it('drops a hostile icon code in both the current and forecast sinks', () => {
     const node = generateMarkup(
       element,
       data({
         weather: {
-          ...data().weather,
+          days: { days: 2 },
+          currentMin: { icon: ATTR, description: 'Scattered clouds' },
           forecastMin: [{ date: '2021-03-15', temp: 10, weather: { icon: ATTR, description: ATTR } }]
         }
       })
     )
     noHandlers(node)
-    // The icon is allowlisted, not escaped, so a hostile code yields no img at all.
+    // Allowlisted, not escaped, so a hostile code yields no img at all in either place.
     expect(node.querySelectorAll('.travel-forecast img').length).toBe(0)
+    expect(node.querySelectorAll('.container img').length).toBe(0)
   })
 
   // The warning is interpolated into element content, so TEXT is the payload that matters.
@@ -117,6 +125,29 @@ describe('generateMarkup escapes every sink', () => {
     )
     noHandlers(node)
     expect(node.textContent).toContain(payload)
+    expect(window.__pwned).toBeUndefined()
+  })
+
+  // A VALID icon with a hostile description, which is the only way to reach the alt beside it.
+  // When the icon is hostile the allowlist drops the whole <img>, so the alt never renders and
+  // removing its escaping is invisible: measured, that poison left all 63 tests green. A guard
+  // that short-circuits hides every guard downstream of it.
+  it('escapes the alt beside a valid icon, in both weather sinks', () => {
+    const node = generateMarkup(
+      element,
+      data({
+        city: { name: ATTR, lat: '1', lng: '2' },
+        weather: {
+          days: { days: 2 },
+          currentMin: { icon: 'c02d', description: ATTR },
+          forecastMin: [{ date: '2021-03-15', temp: 10, weather: { icon: 'c04d', description: ATTR } }]
+        }
+      })
+    )
+    // Both imgs must exist, or this test never reaches the alt attributes at all.
+    expect(node.querySelectorAll('.container img').length).toBe(1)
+    expect(node.querySelectorAll('.travel-forecast img').length).toBe(1)
+    noHandlers(node)
     expect(window.__pwned).toBeUndefined()
   })
 

--- a/src/client/js/__tests__/markup.test.js
+++ b/src/client/js/__tests__/markup.test.js
@@ -222,6 +222,52 @@ describe('generateMarkup escapes every sink', () => {
 // jest.config.js is load-bearing. Without this, removing the pin would silently disable that
 // test rather than break anything, which is the same failure shape as a test whose payload
 // cannot escape its context.
+describe('forecast entries with unusable dates', () => {
+  // The server parser filters null and primitive ENTRIES but does not look inside a valid
+  // object, so an entry with a missing or unparseable datetime reached this loop and rendered
+  // NaN/NaN.
+  it.each([
+    ['a missing date', undefined],
+    ['an empty date', ''],
+    ['an unparseable date', 'not-a-date'],
+    ['a null date', null],
+    ['a numeric zero date', 0],
+    ['a numeric timestamp', 1615766400000]
+  ])('skips an entry with %s rather than rendering NaN', (_label, date) => {
+    const node = generateMarkup(
+      element,
+      data({
+        weather: {
+          days: { days: 1 },
+          currentMin: { icon: 'c02d', description: 'ok' },
+          forecastMin: [{ date, temp: 9, weather: { icon: 'c01d', description: 'ok' } }]
+        }
+      })
+    )
+    expect(node.textContent).not.toContain('NaN')
+    expect(node.querySelectorAll('.travel-forecast .flex-item').length).toBe(0)
+  })
+
+  it('keeps the valid entries alongside an invalid one', () => {
+    const node = generateMarkup(
+      element,
+      data({
+        weather: {
+          days: { days: 2 },
+          currentMin: { icon: 'c02d', description: 'ok' },
+          forecastMin: [
+            { date: 'nonsense', temp: 1, weather: { icon: 'c01d', description: 'a' } },
+            { date: '2021-03-16', temp: 2, weather: { icon: 'c01d', description: 'b' } }
+          ]
+        }
+      })
+    )
+    expect(node.textContent).not.toContain('NaN')
+    expect(node.querySelectorAll('.travel-forecast .flex-item').length).toBe(1)
+    expect(node.textContent).toContain('3/16')
+  })
+})
+
 describe('the test environment itself', () => {
   it('runs in a non-UTC timezone, or the UTC date test cannot fail', () => {
     const offset = new Date('2021-03-15T00:00:00Z').getTimezoneOffset()

--- a/src/client/js/fetch/post.js
+++ b/src/client/js/fetch/post.js
@@ -1,7 +1,6 @@
 import { validateData } from '../validations/index'
 
 const postDataToBackend = async (url, data) => {
-
   validateData('object', data)
 
   try {

--- a/src/client/js/handlers/index.js
+++ b/src/client/js/handlers/index.js
@@ -3,7 +3,6 @@ import { generateMarkup, addMarkup } from '../UI/markup'
 import { shouldNotBeEmpty } from '../validations/index'
 
 const onClickHandler = async () => {
-
   const fromPlace = document.querySelector('input[id="from-place"]').value
   const toPlace = document.querySelector('input[id="to-place"]').value
   const fromDate = document.querySelector('input[id="from-date"]').value
@@ -17,7 +16,11 @@ const onClickHandler = async () => {
 
   const emptyInputs = shouldNotBeEmpty(inputsMapping)
   if (emptyInputs !== 0) return
-  const data = await postDataToBackend('http://localhost:8085/api/travels', {
+  // A relative path, not http://localhost:8085. The built bundle is served BY this server,
+  // so a same-origin path works in development and wherever it is deployed. The absolute
+  // localhost URL meant the production bundle could only ever talk to the developer's own
+  // machine, and it is what forced the wide-open CORS the server used to have.
+  const data = await postDataToBackend('/api/travels', {
     city: toPlace,
     dates: { fromDate, toDate }
   })

--- a/src/server/API/geonames.js
+++ b/src/server/API/geonames.js
@@ -5,7 +5,9 @@ import fetch from 'node-fetch'
 import { validatePropertiesObj } from '../validations/index'
 
 const geoAPI = {
-  baseURL: 'http://api.geonames.org/',
+  // https, not http: the username travels in the query string and plain HTTP puts it on
+  // the wire in clear text. geonames serves the same API over TLS.
+  baseURL: 'https://secure.geonames.org/',
   apiKey: process.env.GEONAMES_API_KEY,
   maxRows: 1
 }
@@ -31,8 +33,14 @@ const geoGetCityInfo = async (geoAPIBaseObject, city) => {
   }
 }
 
+// Returns undefined rather than throwing when the response has no `geonames` array.
+// It used to do `for (let obj of apiResponse.geonames)`, which threw
+// `TypeError: objArr is not iterable` both for `{}` and for the Error object the catch
+// block above returns on a network failure. Inside an async express handler that became an
+// unhandled rejection: a hung request on Node 14, a dead process on Node 15+.
 const parsedGeoGetCityInfo = (apiResponse = {}) => {
-  const objArr = apiResponse.geonames
+  const objArr = apiResponse && apiResponse.geonames
+  if (!Array.isArray(objArr) || objArr.length === 0) return undefined
   const parsedData = []
   for (let obj of objArr) {
     const { lng, lat, name } = obj

--- a/src/server/API/geonames.js
+++ b/src/server/API/geonames.js
@@ -28,8 +28,15 @@ const geoGetCityInfo = async (geoAPIBaseObject, city) => {
 
     return res
   } catch (err) {
+    // Re-thrown, not returned. This used to `return err`, which meant a network failure or a
+    // bad JSON body left an Error object standing in for a response. Downstream that error
+    // reached validateResponse and the parsers, so a geonames outage produced a false 404
+    // ("We do not have that city in our records") and a weatherbit or pixabay outage produced
+    // a 200 with empty fallback data. Measured before this change, with node-fetch rejecting:
+    // POST /api/travels answered 404. The route's try/catch turns a throw into a 502, which is
+    // the honest answer for "an upstream service failed".
     console.log(`ERROR: geoGetCityInfo - ${err}`)
-    return err
+    throw err instanceof Error ? err : new Error(String(err))
   }
 }
 

--- a/src/server/API/geonames.js
+++ b/src/server/API/geonames.js
@@ -2,6 +2,7 @@ import dotenv from 'dotenv'
 dotenv.config({})
 
 import fetch from 'node-fetch'
+import { describeError } from '../utils/logging'
 import { validatePropertiesObj } from '../validations/index'
 
 const geoAPI = {
@@ -35,7 +36,7 @@ const geoGetCityInfo = async (geoAPIBaseObject, city) => {
     // a 200 with empty fallback data. Measured before this change, with node-fetch rejecting:
     // POST /api/travels answered 404. The route's try/catch turns a throw into a 502, which is
     // the honest answer for "an upstream service failed".
-    console.log(`ERROR: geoGetCityInfo - ${err}`)
+    console.log(describeError('geoGetCityInfo', err))
     throw err instanceof Error ? err : new Error(String(err))
   }
 }

--- a/src/server/API/pixabay.js
+++ b/src/server/API/pixabay.js
@@ -23,8 +23,15 @@ const pixaGetCityImage = async (pixaAPIBaseObject, city) => {
     const res = await req.json()
     return res
   } catch (err) {
+    // Re-thrown, not returned. This used to `return err`, which meant a network failure or a
+    // bad JSON body left an Error object standing in for a response. Downstream that error
+    // reached validateResponse and the parsers, so a geonames outage produced a false 404
+    // ("We do not have that city in our records") and a weatherbit or pixabay outage produced
+    // a 200 with empty fallback data. Measured before this change, with node-fetch rejecting:
+    // POST /api/travels answered 404. The route's try/catch turns a throw into a 502, which is
+    // the honest answer for "an upstream service failed".
     console.log(`ERROR: pixaGetCityImage - ${err}`)
-    return err
+    throw err instanceof Error ? err : new Error(String(err))
   }
 }
 

--- a/src/server/API/pixabay.js
+++ b/src/server/API/pixabay.js
@@ -28,8 +28,12 @@ const pixaGetCityImage = async (pixaAPIBaseObject, city) => {
   }
 }
 
+// Same guard as the geonames parser: `hits` is absent on an error response, and
+// `for...of undefined` threw. Pixabay also legitimately returns zero hits for an obscure
+// query, so an empty array is a normal answer, not a failure.
 const parsedPixaGetCityImage = (apiResponse = {}) => {
-  const objArr = apiResponse.hits
+  const objArr = apiResponse && apiResponse.hits
+  if (!Array.isArray(objArr)) return []
   const parsedData = []
   for (let obj of objArr) {
     const { previewURL, tags } = obj

--- a/src/server/API/pixabay.js
+++ b/src/server/API/pixabay.js
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv'
 dotenv.config({})
 import fetch from 'node-fetch'
+import { describeError } from '../utils/logging'
 import { validatePropertiesObj } from '../validations/index'
 
 const pixaAPI = {
@@ -30,7 +31,7 @@ const pixaGetCityImage = async (pixaAPIBaseObject, city) => {
     // a 200 with empty fallback data. Measured before this change, with node-fetch rejecting:
     // POST /api/travels answered 404. The route's try/catch turns a throw into a 502, which is
     // the honest answer for "an upstream service failed".
-    console.log(`ERROR: pixaGetCityImage - ${err}`)
+    console.log(describeError('pixaGetCityImage', err))
     throw err instanceof Error ? err : new Error(String(err))
   }
 }

--- a/src/server/API/weatherbit.js
+++ b/src/server/API/weatherbit.js
@@ -27,9 +27,16 @@ const getRequest = async (
 
     // Two bugs were in this one line.
     //
-    // 1. `lat=${lat}6` appended a stray 6 to every latitude. Measured: a lat of 40.7128
-    //    was sent as 40.71286. It never errored, it just asked about the wrong place, and
-    //    how wrong depended on how many decimals the coordinate happened to have.
+    // 1. `lat=${lat}6` appended a stray 6 to every latitude, and the damage scales inversely
+    //    with precision, so quoting a high-precision example understates it badly:
+    //
+    //      40.7128 -> 40.71286   0.0001 deg, about 11 m
+    //      51.5    -> 51.56      0.06 deg,   about 6.7 km
+    //      4       -> 46         42 deg,     about 4,700 km
+    //      0       -> 6          6 deg
+    //
+    //    geonames returns whatever precision it has, so a low-precision latitude asked
+    //    about a different continent. It never errored either way.
     //
     // 2. `${api}/daily` is only correct for one of the two callers. Per Weatherbit's docs
     //    the current-conditions endpoint is `/v2.0/current` and there is no

--- a/src/server/API/weatherbit.js
+++ b/src/server/API/weatherbit.js
@@ -25,7 +25,17 @@ const getRequest = async (
       throw 'Properties validation error'
     }
 
-    let builtURL = `${baseURL}${api}/daily?key=${apiKey}&lat=${lat}6&lon=${lng}`
+    // Two bugs were in this one line.
+    //
+    // 1. `lat=${lat}6` appended a stray 6 to every latitude. Measured: a lat of 40.7128
+    //    was sent as 40.71286. It never errored, it just asked about the wrong place, and
+    //    how wrong depended on how many decimals the coordinate happened to have.
+    //
+    // 2. `${api}/daily` is only correct for one of the two callers. Per Weatherbit's docs
+    //    the current-conditions endpoint is `/v2.0/current` and there is no
+    //    `/current/daily`; the 16-day forecast is `/v2.0/forecast/daily`. So the current
+    //    call was hitting a path that does not exist.
+    let builtURL = `${baseURL}${api}?key=${apiKey}&lat=${lat}&lon=${lng}`
     if (extraParams) builtURL += `${extraParams}`
 
     const req = await fetch(builtURL)
@@ -52,7 +62,7 @@ const weatherGetCity = async (weatherAPIBaseObject, cityObj, dates) => {
   const extraParameters = `&days=${days}`
   const forecastWeather = await getRequest(
     weatherAPI,
-    'forecast',
+    'forecast/daily',
     requiredProperties,
     weatherAPIBaseObject,
     cityObj,
@@ -68,11 +78,17 @@ const weatherGetCity = async (weatherAPIBaseObject, cityObj, dates) => {
   return weatherObj
 }
 
+// Guarded for the same reason as the other two parsers: `apiResponse.current.data[0]` threw
+// a TypeError whenever the upstream call failed, because the catch block above returns the
+// error object as though it were data. That surfaced as a hung request on Node 14 and a
+// dead process on Node 15+.
 const parsedWeatherGetCity = (apiResponse = {}) => {
-  const days = apiResponse.days
-  const currentMin = apiResponse.current.data[0].weather
+  const days = apiResponse && apiResponse.days
+  const currentData = apiResponse && apiResponse.current && apiResponse.current.data
+  const currentMin = Array.isArray(currentData) && currentData.length > 0 ? currentData[0].weather : null
+  const forecastData = apiResponse && apiResponse.forecast && apiResponse.forecast.data
   let forecastMin = []
-  for (let element of apiResponse.forecast.data) {
+  for (let element of Array.isArray(forecastData) ? forecastData : []) {
     const { datetime, temp, weather } = element
     forecastMin.push({
       date: datetime,

--- a/src/server/API/weatherbit.js
+++ b/src/server/API/weatherbit.js
@@ -50,8 +50,15 @@ const getRequest = async (
 
     return res
   } catch (err) {
+    // Re-thrown, not returned. This used to `return err`, which meant a network failure or a
+    // bad JSON body left an Error object standing in for a response. Downstream that error
+    // reached validateResponse and the parsers, so a geonames outage produced a false 404
+    // ("We do not have that city in our records") and a weatherbit or pixabay outage produced
+    // a 200 with empty fallback data. Measured before this change, with node-fetch rejecting:
+    // POST /api/travels answered 404. The route's try/catch turns a throw into a 502, which is
+    // the honest answer for "an upstream service failed".
     console.log(`ERROR: weatherGetCity - ${err}`)
-    return err
+    throw err instanceof Error ? err : new Error(String(err))
   }
 }
 
@@ -97,11 +104,15 @@ const weatherGetCity = async (weatherAPIBaseObject, cityObj, dates) => {
 // dead process on Node 15+.
 const parsedWeatherGetCity = (apiResponse = {}) => {
   const days = apiResponse && apiResponse.days
+  // Elements are checked, not just the arrays. An upstream response can carry
+  // `data: [null]`, and `currentData[0].weather` or destructuring a null element throws,
+  // which defeats the whole point of returning a documented fallback.
+  const isObj = (v) => v !== null && typeof v === 'object'
   const currentData = apiResponse && apiResponse.current && apiResponse.current.data
-  const currentMin = Array.isArray(currentData) && currentData.length > 0 ? currentData[0].weather : null
+  const currentMin = Array.isArray(currentData) && isObj(currentData[0]) ? currentData[0].weather : null
   const forecastData = apiResponse && apiResponse.forecast && apiResponse.forecast.data
   let forecastMin = []
-  for (let element of Array.isArray(forecastData) ? forecastData : []) {
+  for (let element of (Array.isArray(forecastData) ? forecastData : []).filter(isObj)) {
     const { datetime, temp, weather } = element
     forecastMin.push({
       date: datetime,

--- a/src/server/API/weatherbit.js
+++ b/src/server/API/weatherbit.js
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv'
 dotenv.config({})
 import fetch from 'node-fetch'
+import { describeError } from '../utils/logging'
 import { validatePropertiesObj, warningForMaxDaysForecastAPI } from '../validations/index'
 import { getDiffDatesInDays } from '../utils/index'
 
@@ -57,7 +58,7 @@ const getRequest = async (
     // a 200 with empty fallback data. Measured before this change, with node-fetch rejecting:
     // POST /api/travels answered 404. The route's try/catch turns a throw into a 502, which is
     // the honest answer for "an upstream service failed".
-    console.log(`ERROR: weatherGetCity - ${err}`)
+    console.log(describeError('weatherGetCity', err))
     throw err instanceof Error ? err : new Error(String(err))
   }
 }

--- a/src/server/API/weatherbit.js
+++ b/src/server/API/weatherbit.js
@@ -57,14 +57,20 @@ const weatherGetCity = async (weatherAPIBaseObject, cityObj, dates) => {
 
   const requiredProperties = ['baseURL', 'apiKey']
 
-  const currentWeather = await getRequest(weatherAPI, 'current', requiredProperties, weatherAPIBaseObject, cityObj)
+  // The config passed in is the one used, not the module-level weatherAPI. It used to
+  // validate the argument and then build the URL from the module constant, so a caller could
+  // hand in a perfectly good object and have it ignored. That also made this function
+  // untestable without setting process.env before importing the module.
+  const config = weatherAPIBaseObject || weatherAPI
+
+  const currentWeather = await getRequest(config, 'current', requiredProperties, config, cityObj)
 
   const extraParameters = `&days=${days}`
   const forecastWeather = await getRequest(
-    weatherAPI,
+    config,
     'forecast/daily',
     requiredProperties,
-    weatherAPIBaseObject,
+    config,
     cityObj,
     extraParameters
   )

--- a/src/server/__tests__/logging.test.js
+++ b/src/server/__tests__/logging.test.js
@@ -1,0 +1,46 @@
+import { describeError } from '../utils/logging'
+
+// The literal below is a stand-in for a real key. What matters is that describeError never
+// returns it, whatever shape of error node-fetch produced.
+const KEY = 'SUPERSECRET123456'
+
+describe('describeError never emits a request URL or a credential', () => {
+  const errors = [
+    [
+      'node-fetch network failure',
+      Object.assign(
+        new Error(
+          `request to https://api.geonames.org/searchJSON?q=London&username=${KEY} failed, reason: getaddrinfo ENOTFOUND`
+        ),
+        { name: 'FetchError', type: 'system', code: 'ENOTFOUND' }
+      )
+    ],
+    [
+      'node-fetch invalid json',
+      Object.assign(
+        new Error(`invalid json response body at https://pixabay.com/api/?key=${KEY} reason: Unexpected token <`),
+        { name: 'FetchError', type: 'invalid-json' }
+      )
+    ],
+    ['a plain Error carrying a URL', new Error(`boom https://x/?key=${KEY}`)],
+    ['a thrown string', `failed for https://x/?key=${KEY}`],
+    ['null', null],
+    ['undefined', undefined]
+  ]
+
+  it.each(errors)('redacts %s', (_label, err) => {
+    const out = describeError('op', err)
+    expect(out).not.toContain(KEY)
+    expect(out).not.toContain('http')
+    expect(out).not.toContain('key=')
+    expect(out).not.toContain('username=')
+  })
+
+  it('still says enough to diagnose with', () => {
+    const err = Object.assign(new Error(`request to https://x/?key=${KEY} failed`), {
+      name: 'FetchError',
+      code: 'ENOTFOUND'
+    })
+    expect(describeError('geoGetCityInfo', err)).toBe('geoGetCityInfo: FetchError (code: ENOTFOUND)')
+  })
+})

--- a/src/server/__tests__/parsers.test.js
+++ b/src/server/__tests__/parsers.test.js
@@ -56,3 +56,23 @@ describe('parsers still parse a good response', () => {
     expect(res.forecastMin).toEqual([{ date: '2021-03-15', temp: 10.2, weather: { icon: 'c04d' } }])
   })
 })
+
+describe('parsers survive null ELEMENTS, not just missing arrays', () => {
+  it('weatherbit tolerates current.data: [null]', () => {
+    expect(() => parsedWeatherGetCity({ current: { data: [null] }, forecast: { data: [] } })).not.toThrow()
+    expect(parsedWeatherGetCity({ current: { data: [null] }, forecast: { data: [] } }).currentMin).toBeNull()
+  })
+
+  it('weatherbit skips null forecast elements rather than destructuring them', () => {
+    const res = parsedWeatherGetCity({
+      current: { data: [] },
+      forecast: { data: [null, { datetime: '2021-03-15', temp: 9, weather: { icon: 'c01d' } }, null] }
+    })
+    expect(res.forecastMin).toHaveLength(1)
+    expect(res.forecastMin[0].date).toBe('2021-03-15')
+  })
+
+  it('weatherbit tolerates a primitive inside the arrays', () => {
+    expect(() => parsedWeatherGetCity({ current: { data: ['x'] }, forecast: { data: [42] } })).not.toThrow()
+  })
+})

--- a/src/server/__tests__/parsers.test.js
+++ b/src/server/__tests__/parsers.test.js
@@ -1,0 +1,58 @@
+import { parsedGeoGetCityInfo } from '../API/geonames'
+import { parsedPixaGetCityImage } from '../API/pixabay'
+import { parsedWeatherGetCity } from '../API/weatherbit'
+
+// Every one of these threw a TypeError before. The catch blocks in the API modules `return
+// err`, so the error object itself reached these parsers, and `for...of undefined` is not a
+// recoverable situation inside an async express handler: measured as a hung request on
+// Node 14 and a process exit on Node 15+.
+const badInputs = [
+  ['an empty object', {}],
+  ['an Error, which is what the catch blocks return', new Error('network down')],
+  ['null', null],
+  ['a string', 'not json']
+]
+
+describe('parsers survive what the API modules actually hand them', () => {
+  for (const [label, input] of badInputs) {
+    it(`parsedGeoGetCityInfo tolerates ${label}`, () => {
+      expect(() => parsedGeoGetCityInfo(input)).not.toThrow()
+      expect(parsedGeoGetCityInfo(input)).toBeUndefined()
+    })
+
+    it(`parsedPixaGetCityImage tolerates ${label}`, () => {
+      expect(() => parsedPixaGetCityImage(input)).not.toThrow()
+      expect(parsedPixaGetCityImage(input)).toEqual([])
+    })
+
+    it(`parsedWeatherGetCity tolerates ${label}`, () => {
+      expect(() => parsedWeatherGetCity(input)).not.toThrow()
+      expect(parsedWeatherGetCity(input).forecastMin).toEqual([])
+    })
+  }
+})
+
+describe('parsers still parse a good response', () => {
+  it('geonames returns the first city, flattened', () => {
+    const res = parsedGeoGetCityInfo({
+      totalResultsCount: 1,
+      geonames: [{ lng: '-0.12574', lat: '51.50853', name: 'London', extra: 'dropped' }]
+    })
+    expect(res).toEqual({ lng: '-0.12574', lat: '51.50853', name: 'London' })
+  })
+
+  it('pixabay keeps previewURL and tags only', () => {
+    const res = parsedPixaGetCityImage({ hits: [{ previewURL: 'https://x/a.jpg', tags: 'city', id: 9 }] })
+    expect(res).toEqual([{ previewURL: 'https://x/a.jpg', tags: 'city' }])
+  })
+
+  it('weatherbit composes current and forecast', () => {
+    const res = parsedWeatherGetCity({
+      days: { days: 2 },
+      current: { data: [{ weather: { icon: 'c02d', description: 'Scattered clouds' } }] },
+      forecast: { data: [{ datetime: '2021-03-15', temp: 10.2, weather: { icon: 'c04d' } }] }
+    })
+    expect(res.currentMin).toEqual({ icon: 'c02d', description: 'Scattered clouds' })
+    expect(res.forecastMin).toEqual([{ date: '2021-03-15', temp: 10.2, weather: { icon: 'c04d' } }])
+  })
+})

--- a/src/server/__tests__/route.test.js
+++ b/src/server/__tests__/route.test.js
@@ -1,0 +1,134 @@
+// The three API modules are mocked so no key and no network are needed. What is under test
+// is the route's own behaviour: input validation, the not-found path, and above all what
+// happens when an upstream call blows up.
+// Inline factories, then require() the mocked modules. Two things forced this shape:
+//
+//   - `jest.mock(path)` with no factory does not work here at all. jest-esm-transformer
+//     compiles `export { a, b }` into read-only getters on exports, so automocking yields
+//     plain values and `geoGetCityInfo.mockResolvedValue` is not a function.
+//   - Declaring the mock objects as outer consts and referencing them from the factory does
+//     not work either: jest hoists jest.mock calls above the const declarations, so the
+//     module under test received a different object and every call fell through to a 404.
+//   - `import app from '../app'` at the top loaded the real API modules BEFORE the mocks
+//     applied, because jest-esm-transformer does not run babel-plugin-jest-hoist, so
+//     jest.mock calls are NOT hoisted above ESM imports here. Measured: the route answered
+//     404 for every case and geoGetCityInfo.mock.calls.length was 0, i.e. the real module
+//     had run. Requiring the app AFTER the mock calls gives 200 and one recorded call.
+//
+// Defining the jest.fn()s inside the factory, and require()ing both the mocks and the app
+// after those calls, avoids all three.
+jest.mock('../API/geonames', () => ({
+  geoAPI: { baseURL: 'https://x/', apiKey: 'k', maxRows: 1 },
+  geoGetCityInfo: jest.fn(),
+  parsedGeoGetCityInfo: jest.fn()
+}))
+jest.mock('../API/weatherbit', () => ({
+  weatherAPI: { baseURL: 'https://y/', apiKey: 'k' },
+  weatherGetCity: jest.fn(),
+  parsedWeatherGetCity: jest.fn()
+}))
+jest.mock('../API/pixabay', () => ({
+  pixaAPI: { baseURL: 'https://z/', apiKey: 'k' },
+  pixaGetCityImage: jest.fn(),
+  parsedPixaGetCityImage: jest.fn()
+}))
+
+const request = require('supertest')
+const geonames = require('../API/geonames')
+const weatherbit = require('../API/weatherbit')
+const pixabay = require('../API/pixabay')
+const app = require('../app').default
+
+const GOOD_GEO = { totalResultsCount: 1, geonames: [{ lng: '-0.1', lat: '51.5', name: 'London' }] }
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  geonames.geoGetCityInfo.mockResolvedValue(GOOD_GEO)
+  geonames.parsedGeoGetCityInfo.mockReturnValue({ lng: '-0.1', lat: '51.5', name: 'London' })
+  weatherbit.weatherGetCity.mockResolvedValue({})
+  weatherbit.parsedWeatherGetCity.mockReturnValue({ days: { days: 2 }, currentMin: null, forecastMin: [] })
+  pixabay.pixaGetCityImage.mockResolvedValue({ hits: [] })
+  pixabay.parsedPixaGetCityImage.mockReturnValue([])
+})
+
+const body = { city: 'London', dates: { fromDate: '2021-03-15', toDate: '2021-03-17' } }
+
+describe('POST /api/travels', () => {
+  it('composes the three responses on the happy path', async () => {
+    const res = await request(app).post('/api/travels').send(body)
+    expect(res.status).toBe(200)
+    expect(res.body.city.name).toBe('London')
+    expect(res.body).toHaveProperty('weather')
+    expect(res.body).toHaveProperty('photos')
+  })
+
+  it('rejects a missing or blank city with 400', async () => {
+    for (const bad of [{}, { city: '   ', dates: body.dates }, { city: 42, dates: body.dates }]) {
+      const res = await request(app).post('/api/travels').send(bad)
+      expect(res.status).toBe(400)
+      expect(res.body.error.type).toBe('city')
+    }
+  })
+
+  it('rejects missing dates with 400', async () => {
+    const res = await request(app).post('/api/travels').send({ city: 'London' })
+    expect(res.status).toBe(400)
+    expect(res.body.error.type).toBe('dates')
+  })
+
+  it('answers 404 when the city is not in the geocoding results', async () => {
+    geonames.geoGetCityInfo.mockResolvedValue({ totalResultsCount: 0 })
+    const res = await request(app).post('/api/travels').send(body)
+    expect(res.status).toBe(404)
+    expect(res.body.error.type).toBe('city')
+  })
+
+  // This is the test that matters most. Before the error middleware existed, a throw here
+  // was an unhandled promise rejection inside an async express 4 handler: measured as a
+  // request that never gets a response on Node 14, and a process that exits code 1 on
+  // Node 15+. Either way the client waits forever. A 502 is the whole point.
+  it.each([
+    ['geonames lookup', () => geonames.geoGetCityInfo.mockRejectedValue(new Error('geonames down'))],
+    [
+      'geonames parser',
+      () =>
+        geonames.parsedGeoGetCityInfo.mockImplementation(() => {
+          throw new TypeError('objArr is not iterable')
+        })
+    ],
+    ['weather lookup', () => weatherbit.weatherGetCity.mockRejectedValue(new Error('weatherbit down'))],
+    [
+      'weather parser',
+      () =>
+        weatherbit.parsedWeatherGetCity.mockImplementation(() => {
+          throw new TypeError('cannot read data')
+        })
+    ],
+    ['pixabay lookup', () => pixabay.pixaGetCityImage.mockRejectedValue(new Error('pixabay down'))],
+    [
+      'pixabay parser',
+      () =>
+        pixabay.parsedPixaGetCityImage.mockImplementation(() => {
+          throw new TypeError('hits is not iterable')
+        })
+    ]
+  ])('answers 502 instead of hanging when the %s fails', async (_label, arrange) => {
+    arrange()
+    const res = await request(app).post('/api/travels').send(body)
+    expect(res.status).toBe(502)
+    expect(res.body.error.type).toBe('upstream')
+  })
+
+  it('answers 502 when geocoding returns nothing usable', async () => {
+    geonames.parsedGeoGetCityInfo.mockReturnValue(undefined)
+    const res = await request(app).post('/api/travels').send(body)
+    expect(res.status).toBe(502)
+  })
+})
+
+describe('CORS', () => {
+  it('does not send a wildcard allow-origin', async () => {
+    const res = await request(app).post('/api/travels').set('Origin', 'https://evil.example').send(body)
+    expect(res.headers['access-control-allow-origin']).not.toBe('*')
+  })
+})

--- a/src/server/__tests__/route.test.js
+++ b/src/server/__tests__/route.test.js
@@ -159,3 +159,28 @@ describe('date validation', () => {
     expect(res.status).toBe(200)
   })
 })
+
+describe('calendar-invalid dates', () => {
+  const withDates = (fromDate, toDate) => ({ city: 'London', dates: { fromDate, toDate } })
+
+  // new Date('2021-02-30') does not throw, it normalises to 2 March 2021. So a date that does
+  // not exist used to pass validation and become a real trip.
+  it.each([
+    ['30 February', '2021-02-30'],
+    ['31 April', '2021-04-31'],
+    ['month 13', '2021-13-01'],
+    ['day 32', '2021-01-32'],
+    ['29 February in a non-leap year', '2021-02-29'],
+    ['not zero-padded', '2021-3-5'],
+    ['a full timestamp', '2021-03-15T00:00:00Z']
+  ])('rejects %s', async (_label, bad) => {
+    const res = await request(app).post('/api/travels').send(withDates(bad, '2021-03-17'))
+    expect(res.status).toBe(400)
+    expect(res.body.error.type).toBe('dates')
+  })
+
+  it('accepts 29 February in a leap year', async () => {
+    const res = await request(app).post('/api/travels').send(withDates('2020-02-29', '2020-03-01'))
+    expect(res.status).toBe(200)
+  })
+})

--- a/src/server/__tests__/route.test.js
+++ b/src/server/__tests__/route.test.js
@@ -132,3 +132,30 @@ describe('CORS', () => {
     expect(res.headers['access-control-allow-origin']).not.toBe('*')
   })
 })
+
+describe('date validation', () => {
+  const withDates = (fromDate, toDate) => ({ city: 'London', dates: { fromDate, toDate } })
+
+  it('rejects unparseable dates', async () => {
+    for (const bad of [
+      ['invalid', '2021-03-17'],
+      ['2021-03-15', 'nonsense'],
+      ['', '']
+    ]) {
+      const res = await request(app).post('/api/travels').send(withDates(bad[0], bad[1]))
+      expect(res.status).toBe(400)
+      expect(res.body.error.type).toBe('dates')
+    }
+  })
+
+  it('rejects a reversed range', async () => {
+    const res = await request(app).post('/api/travels').send(withDates('2021-03-17', '2021-03-15'))
+    expect(res.status).toBe(400)
+    expect(res.body.error.msg).toMatch(/precede/)
+  })
+
+  it('accepts a single-day range', async () => {
+    const res = await request(app).post('/api/travels').send(withDates('2021-03-15', '2021-03-15'))
+    expect(res.status).toBe(200)
+  })
+})

--- a/src/server/__tests__/upstream.test.js
+++ b/src/server/__tests__/upstream.test.js
@@ -1,0 +1,63 @@
+// The point of this file is that it uses the REAL API modules with only node-fetch mocked.
+// route.test.js mocks the modules themselves, which is fine for routing logic but cannot show
+// what happens on a genuine upstream failure: the modules used to catch and return the Error,
+// so the route saw data rather than a rejection and answered 404 or 200. Measured before the
+// fix: a geonames outage returned 404 "We do not have that city in our records".
+jest.mock('node-fetch', () => jest.fn())
+
+// Set before the require: the API modules read their keys into module-level constants at
+// import time. One character, because the value is irrelevant here and the repo's pre-commit
+// scanner blocks api[_-]?key followed by a quoted literal of 8 or more characters.
+process.env.GEONAMES_API_KEY = 'k'
+process.env.WEATHERBIT_API_KEY = 'k'
+process.env.PIXABAY_API_KEY = 'k'
+
+const fetch = require('node-fetch')
+const request = require('supertest')
+const app = require('../app').default
+
+const body = { city: 'London', dates: { fromDate: '2021-03-15', toDate: '2021-03-17' } }
+
+beforeEach(() => fetch.mockReset())
+
+describe('a real upstream failure reaches the error middleware', () => {
+  it('answers 502, not a false 404, when the network is down', async () => {
+    fetch.mockRejectedValue(new Error('ENOTFOUND api.geonames.org'))
+    const res = await request(app).post('/api/travels').send(body)
+    expect(res.status).toBe(502)
+    expect(res.body.error.type).toBe('upstream')
+  })
+
+  it('answers 502 when a response body is not JSON', async () => {
+    fetch.mockResolvedValue({
+      json: async () => {
+        throw new SyntaxError('Unexpected token < in JSON at position 0')
+      }
+    })
+    const res = await request(app).post('/api/travels').send(body)
+    expect(res.status).toBe(502)
+  })
+
+  it('still answers 404 for a city the geocoder genuinely does not know', async () => {
+    // The distinction that matters: an empty result is not a failure.
+    fetch.mockResolvedValue({ json: async () => ({ totalResultsCount: 0 }) })
+    const res = await request(app).post('/api/travels').send(body)
+    expect(res.status).toBe(404)
+    expect(res.body.error.type).toBe('city')
+  })
+
+  it('answers 502 when a key is missing, rather than a misleading 404', async () => {
+    // A side effect of the re-throw worth having: geoGetCityInfo validates that its config
+    // carries an apiKey and throws when it does not. That used to be swallowed and become
+    // "We do not have that city in our records", so a misconfigured deployment looked like
+    // every city being unknown. The module is re-required with no key to show it.
+    jest.resetModules()
+    delete process.env.GEONAMES_API_KEY
+    const freshApp = require('../app').default
+    const freshFetch = require('node-fetch')
+    freshFetch.mockResolvedValue({ json: async () => ({ totalResultsCount: 1 }) })
+    const res = await request(freshApp).post('/api/travels').send(body)
+    expect(res.status).toBe(502)
+    process.env.GEONAMES_API_KEY = 'k'
+  })
+})

--- a/src/server/__tests__/upstream.test.js
+++ b/src/server/__tests__/upstream.test.js
@@ -61,3 +61,37 @@ describe('a real upstream failure reaches the error middleware', () => {
     process.env.GEONAMES_API_KEY = 'k'
   })
 })
+
+describe('no log line carries the credential', () => {
+  // End to end through the REAL modules: node-fetch rejects with a message containing the URL,
+  // and nothing written to the console may contain the key. Before the redaction both the module
+  // log and app.js's err.stack line reproduced it verbatim.
+  it('logs neither the key nor the request URL on an upstream failure', async () => {
+    const written = []
+    const log = jest.spyOn(console, 'log').mockImplementation((m) => written.push(String(m)))
+    const err = jest.spyOn(console, 'error').mockImplementation((m) => written.push(String(m)))
+
+    fetch.mockRejectedValue(
+      new Error('request to https://secure.geonames.org/searchJSON?q=London&username=k failed, reason: ENOTFOUND')
+    )
+    const res = await request(app).post('/api/travels').send(body)
+    expect(res.status).toBe(502)
+
+    log.mockRestore()
+    err.mockRestore()
+
+    expect(written.length).toBeGreaterThan(0)
+    for (const line of written) {
+      expect(line).not.toContain('username=')
+      expect(line).not.toContain('key=')
+      expect(line).not.toContain('http')
+    }
+  })
+
+  it('does not leak the key through the HTTP response either', async () => {
+    fetch.mockRejectedValue(new Error('request to https://x/?key=k failed'))
+    const res = await request(app).post('/api/travels').send(body)
+    expect(JSON.stringify(res.body)).not.toContain('http')
+    expect(JSON.stringify(res.body)).not.toContain('key=')
+  })
+})

--- a/src/server/__tests__/utils.test.js
+++ b/src/server/__tests__/utils.test.js
@@ -1,0 +1,21 @@
+import { formatLongDateToISO, getDiffDatesInDays } from '../utils/index'
+
+describe('formatLongDateToISO', () => {
+  it('reduces a date to its ISO day', () => {
+    expect(formatLongDateToISO('2021-03-15T10:00:00Z')).toBe('2021-03-15')
+  })
+})
+
+describe('getDiffDatesInDays', () => {
+  it('counts whole days between two dates', () => {
+    expect(getDiffDatesInDays({ fromDate: '2021-03-15', toDate: '2021-03-17' })).toBe(2)
+  })
+
+  it('is zero for the same day', () => {
+    expect(getDiffDatesInDays({ fromDate: '2021-03-15', toDate: '2021-03-15' })).toBe(0)
+  })
+
+  it('spans a month boundary', () => {
+    expect(getDiffDatesInDays({ fromDate: '2021-03-30', toDate: '2021-04-02' })).toBe(3)
+  })
+})

--- a/src/server/__tests__/validations.test.js
+++ b/src/server/__tests__/validations.test.js
@@ -1,0 +1,45 @@
+import { validatePropertiesObj, validateResponse, warningForMaxDaysForecastAPI } from '../validations/index'
+
+describe('validateResponse', () => {
+  // The point of these three: the original returned false or undefined and NEVER true, so
+  // the only caller had to test `=== false`. The first case is the one that used to fail.
+  it('returns true for a response that has the key', () => {
+    expect(validateResponse({ totalResultsCount: 3 }, 'totalResultsCount')).toBe(true)
+  })
+
+  it('returns false for zero results', () => {
+    expect(validateResponse({ totalResultsCount: 0 }, 'totalResultsCount')).toBe(false)
+  })
+
+  it('returns false when the key is missing, and for non-objects', () => {
+    expect(validateResponse({}, 'totalResultsCount')).toBe(false)
+    expect(validateResponse(null, 'totalResultsCount')).toBe(false)
+    expect(validateResponse(new Error('network down'), 'totalResultsCount')).toBe(false)
+  })
+
+  it('never returns undefined, which is what made the old version unusable', () => {
+    for (const input of [{ totalResultsCount: 3 }, { totalResultsCount: 0 }, {}, null]) {
+      expect(typeof validateResponse(input, 'totalResultsCount')).toBe('boolean')
+    }
+  })
+})
+
+describe('validatePropertiesObj', () => {
+  it('is true only when every required key is present and truthy', () => {
+    expect(validatePropertiesObj(['a', 'b'], { a: 1, b: 2 })).toBe(true)
+    expect(validatePropertiesObj(['a', 'b'], { a: 1 })).toBe(false)
+    expect(validatePropertiesObj(['a'], { a: '' })).toBe(false)
+  })
+
+  it('is vacuously true with no required properties', () => {
+    expect(validatePropertiesObj([], {})).toBe(true)
+  })
+})
+
+describe('warningForMaxDaysForecastAPI', () => {
+  it('warns above the 16-day ceiling and not at it', () => {
+    expect(warningForMaxDaysForecastAPI(17)).toEqual({ warning: 'We only support forecast for 16 days' })
+    expect(warningForMaxDaysForecastAPI(16)).toBeNull()
+    expect(warningForMaxDaysForecastAPI(1)).toBeNull()
+  })
+})

--- a/src/server/__tests__/weatherbit-url.test.js
+++ b/src/server/__tests__/weatherbit-url.test.js
@@ -1,0 +1,52 @@
+// Guards the two bugs that were in a single line of weatherbit.js and produced no error:
+//   lat=${lat}6  appended a stray digit to every latitude
+//   ${api}/daily gave `current/daily`, a path Weatherbit does not have
+// node-fetch is mocked so the URL can be asserted without a key or a network call.
+jest.mock('node-fetch', () => jest.fn())
+
+const fetch = require('node-fetch')
+const { weatherGetCity } = require('../API/weatherbit')
+
+// The config is injected rather than read from the environment. weatherGetCity used to
+// validate its argument and then build the URL from the module-level constant, which reads
+// process.env at import time; testing it meant setting the variable before the require. It
+// honours the argument now, so this needs no environment at all.
+// The key is one character on purpose. Its value is irrelevant to URL construction, and the
+// repo's pre-commit scanner blocks api[_-]?key followed by a quoted literal of 8 or more
+// characters, which is the right rule to have even when the match is a test fixture.
+const CONFIG = { baseURL: 'https://api.weatherbit.io/v2.0/', apiKey: 'k' }
+
+const CITY = { lat: 40.7128, lng: -74.006, name: 'New York' }
+const DATES = { fromDate: '2021-03-15', toDate: '2021-03-17' }
+
+beforeEach(() => {
+  fetch.mockReset()
+  fetch.mockResolvedValue({ json: async () => ({ data: [] }) })
+})
+
+const urls = async () => {
+  await weatherGetCity(CONFIG, CITY, DATES)
+  return fetch.mock.calls.map((c) => c[0])
+}
+
+describe('weatherbit URL construction', () => {
+  it('sends the latitude exactly, with no trailing digit', async () => {
+    for (const url of await urls()) {
+      expect(url).toContain('lat=40.7128&')
+      expect(url).not.toContain('lat=40.71286')
+    }
+  })
+
+  it('uses the documented paths: /current and /forecast/daily', async () => {
+    const built = await urls()
+    expect(built.some((u) => u.includes('/v2.0/current?'))).toBe(true)
+    expect(built.some((u) => u.includes('/v2.0/forecast/daily?'))).toBe(true)
+    expect(built.some((u) => u.includes('/current/daily'))).toBe(false)
+  })
+
+  it('passes the longitude through and asks for the right number of days', async () => {
+    const built = await urls()
+    for (const url of built) expect(url).toContain('lon=-74.006')
+    expect(built.some((u) => u.includes('&days=2'))).toBe(true)
+  })
+})

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -1,3 +1,4 @@
+import path from 'path'
 import express from 'express'
 import bodyParser from 'body-parser'
 import cors from 'cors'
@@ -10,7 +11,21 @@ import { pixaAPI, pixaGetCityImage, parsedPixaGetCityImage } from './API/pixabay
 
 const app = express()
 
-app.use(cors())
+// `cors()` with no arguments sends Access-Control-Allow-Origin: *, which on a server whose
+// entire purpose is proxying three keyed APIs means any page on the internet can spend your
+// quota. Restrict it to the origins this app is actually served from. CORS_ORIGIN accepts a
+// comma-separated list; with none set, only same-origin requests work, which is what the
+// bundled client does anyway.
+const allowedOrigins = (process.env.CORS_ORIGIN || '')
+  .split(',')
+  .map((o) => o.trim())
+  .filter(Boolean)
+
+app.use(
+  cors({
+    origin: allowedOrigins.length > 0 ? allowedOrigins : false
+  })
+)
 
 app.use(bodyParser.json())
 
@@ -35,13 +50,32 @@ app.post('/api', async function (req, res) {
   res.status(200).send(data)
 })
 
-app.post('/api/travels', async function (req, res) {
-  const { city, dates } = req.body
+app.post('/api/travels', async function (req, res, next) {
+  try {
+    await handleTravels(req, res)
+  } catch (err) {
+    next(err)
+  }
+})
+
+async function handleTravels(req, res) {
+  const { city, dates } = req.body || {}
+
+  if (typeof city !== 'string' || city.trim() === '') {
+    res.status(400).send({ error: { type: 'city', msg: 'A city name is required.' } })
+    return
+  }
+  if (!dates || typeof dates.fromDate !== 'string' || typeof dates.toDate !== 'string') {
+    res.status(400).send({ error: { type: 'dates', msg: 'fromDate and toDate are required.' } })
+    return
+  }
 
   const geoData = await geoGetCityInfo(geoAPI, city)
-  const cityValidation = validateResponse(geoData, 'totalResultsCount')
-  if (cityValidation === false) {
-    res.send({
+  // validateResponse returns true for a usable answer now. It used to return false or
+  // undefined and never true, so this had to be written as `=== false`; anything more
+  // natural, like `if (!cityValidation)`, rejected every city that WAS found.
+  if (!validateResponse(geoData, 'totalResultsCount')) {
+    res.status(404).send({
       error: {
         type: 'city',
         msg: 'We do not have that city in our records!'
@@ -51,6 +85,12 @@ app.post('/api/travels', async function (req, res) {
   }
 
   const geoDataParsed = parsedGeoGetCityInfo(geoData)
+  if (!geoDataParsed) {
+    res.status(502).send({
+      error: { type: 'city', msg: 'The geocoding service returned no usable result.' }
+    })
+    return
+  }
 
   const weatherData = await weatherGetCity(weatherAPI, geoDataParsed, dates)
   const weatherDataParsed = parsedWeatherGetCity(weatherData)
@@ -58,13 +98,25 @@ app.post('/api/travels', async function (req, res) {
   const pixaData = await pixaGetCityImage(pixaAPI, city)
   const pixaDataParsed = parsedPixaGetCityImage(pixaData)
 
-  const response = {
+  res.send({
     city: geoDataParsed,
     weather: weatherDataParsed,
     photos: pixaDataParsed
-  }
+  })
+}
 
-  res.send(response)
+// Express 4 does not catch a rejected promise from an async handler, so without this every
+// unexpected shape from an upstream API became an unhandled rejection. Measured against
+// express 4.17.1: on Node 14 the request simply hangs with no response, and on Node 15+
+// the whole server process exits with code 1. The handler is wrapped above; this turns
+// whatever it threw into a 502.
+// eslint-disable-next-line no-unused-vars
+app.use(function (err, req, res, next) {
+  console.error(`ERROR: /api/travels - ${err && err.stack ? err.stack : err}`)
+  if (res.headersSent) return
+  res.status(502).send({
+    error: { type: 'upstream', msg: 'An upstream service failed or returned an unexpected response.' }
+  })
 })
 
 export default app

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -70,6 +70,21 @@ async function handleTravels(req, res) {
     return
   }
 
+  // Type alone was not enough: 'invalid' is a string, and so is a toDate that precedes
+  // fromDate. Both used to pass straight through to the date arithmetic, where
+  // getDiffDatesInDays produced NaN or a negative day count and sent it to weatherbit as
+  // &days=NaN.
+  const from = new Date(dates.fromDate)
+  const to = new Date(dates.toDate)
+  if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
+    res.status(400).send({ error: { type: 'dates', msg: 'fromDate and toDate must be valid dates.' } })
+    return
+  }
+  if (to.getTime() < from.getTime()) {
+    res.status(400).send({ error: { type: 'dates', msg: 'toDate must not precede fromDate.' } })
+    return
+  }
+
   const geoData = await geoGetCityInfo(geoAPI, city)
   // validateResponse returns true for a usable answer now. It used to return false or
   // undefined and never true, so this had to be written as `=== false`; anything more

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -4,6 +4,7 @@ import bodyParser from 'body-parser'
 import cors from 'cors'
 
 import { validateResponse } from './validations/index'
+import { describeError } from './utils/logging'
 
 import { geoAPI, geoGetCityInfo, parsedGeoGetCityInfo } from './API/geonames'
 import { weatherAPI, weatherGetCity, parsedWeatherGetCity } from './API/weatherbit'
@@ -74,10 +75,31 @@ async function handleTravels(req, res) {
   // fromDate. Both used to pass straight through to the date arithmetic, where
   // getDiffDatesInDays produced NaN or a negative day count and sent it to weatherbit as
   // &days=NaN.
-  const from = new Date(dates.fromDate)
-  const to = new Date(dates.toDate)
-  if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
-    res.status(400).send({ error: { type: 'dates', msg: 'fromDate and toDate must be valid dates.' } })
+  // Strict, because `new Date` normalises rather than rejecting: new Date('2021-02-30') is
+  // 2 March 2021, so a calendar-invalid date passed validation and became a real trip. The
+  // reconstructed components have to match what was asked for.
+  const parseCalendarDate = (value) => {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(value))
+    if (!m) return null
+    const [, y, mo, d] = m
+    const date = new Date(`${y}-${mo}-${d}T00:00:00Z`)
+    if (Number.isNaN(date.getTime())) return null
+    if (
+      date.getUTCFullYear() !== Number(y) ||
+      date.getUTCMonth() + 1 !== Number(mo) ||
+      date.getUTCDate() !== Number(d)
+    ) {
+      return null
+    }
+    return date
+  }
+
+  const from = parseCalendarDate(dates.fromDate)
+  const to = parseCalendarDate(dates.toDate)
+  if (!from || !to) {
+    res.status(400).send({
+      error: { type: 'dates', msg: 'fromDate and toDate must be real calendar dates as YYYY-MM-DD.' }
+    })
     return
   }
   if (to.getTime() < from.getTime()) {
@@ -127,7 +149,9 @@ async function handleTravels(req, res) {
 // whatever it threw into a 502.
 // eslint-disable-next-line no-unused-vars
 app.use(function (err, req, res, next) {
-  console.error(`ERROR: /api/travels - ${err && err.stack ? err.stack : err}`)
+  // NOT err.stack, and not `${err}`. Both carry node-fetch's message, which carries the
+  // request URL, which carries the API key.
+  console.error(describeError('/api/travels', err))
   if (res.headersSent) return
   res.status(502).send({
     error: { type: 'upstream', msg: 'An upstream service failed or returned an unexpected response.' }

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,4 +1,20 @@
 import app from './app'
-const port = 8085
 
-app.listen(port, () => console.log(`Server listening on port ${port}`))
+// PORT from the environment, defaulting to the 8085 this project has always used. A fixed
+// port fails on any host that assigns one.
+const port = process.env.PORT || 8085
+
+const server = app.listen(port, () => console.log(`Server listening on port ${port}`))
+
+// Without this an occupied port produced an unhandled 'error' event rather than a message:
+// on a modern Node that terminates the process with a stack trace and no explanation.
+server.on('error', (err) => {
+  if (err.code === 'EADDRINUSE') {
+    console.error(`Port ${port} is already in use. Set PORT to something else.`)
+  } else {
+    console.error(`Server failed to start: ${err.message}`)
+  }
+  process.exit(1)
+})
+
+export default server

--- a/src/server/utils/logging.js
+++ b/src/server/utils/logging.js
@@ -1,0 +1,20 @@
+// Errors from node-fetch@2.6.1 carry the full request URL in their message, and every URL this
+// project builds has an API key in its query string. Measured on the pinned version:
+//
+//   request to https://…/x?key=SUPERSECRETKEY123 failed, reason: getaddrinfo ENOTFOUND …
+//   invalid json response body at https://…/?key=SUPERSECRETKEY123 reason: Unexpected token …
+//
+// Both contain the key. So interpolating an error into a log line writes the credential to the
+// log, and `err.stack` is worse because it contains the message too. Every log boundary that
+// touches an upstream error goes through this instead.
+//
+// Only fields that cannot carry a URL are kept: the operation name we control, plus the error's
+// name, and its code or type where node-fetch sets one.
+const describeError = (operation, err) => {
+  if (err === null || err === undefined) return `${operation}: unknown error`
+  const name = (err && err.name) || typeof err
+  const code = (err && (err.code || err.type)) || 'none'
+  return `${operation}: ${name} (code: ${code})`
+}
+
+export { describeError }

--- a/src/server/validations/index.js
+++ b/src/server/validations/index.js
@@ -6,9 +6,17 @@ const validatePropertiesObj = (requiredProperties = [], obj = {}) => {
   return true
 }
 
-// For validating external API responses
+// For validating external API responses.
+//
+// This used to be:
+//   if (!data[subKey] || data[subKey] === 0) return false
+// which returns false or UNDEFINED, never true. The only caller compensated by testing
+// `=== false`, so it worked by accident; `if (!validateResponse(...))` would have rejected
+// every city that was found. The `=== 0` clause was also dead, since `!data[subKey]`
+// already catches 0.
 const validateResponse = (data = {}, subKey = '') => {
-  if (!data[subKey] || data[subKey] === 0) return false
+  if (data === null || typeof data !== 'object') return false
+  return Boolean(data[subKey])
 }
 
 // Used for forecast API, which by default, retrieves just 16 days


### PR DESCRIPTION
The happy path returned data, which is why none of this was noticed. Underneath, the weather was for the wrong coordinates, one bad response from a third party could kill the server, and third-party text went into `innerHTML` unescaped. Dependencies are unchanged; every claim below is measured.

## The weather was for the wrong place

One line built the request URL and had two independent bugs:

```js
`${baseURL}${api}/daily?key=${apiKey}&lat=${lat}6&lon=${lng}`
```

**The stray `6`** appended a digit to every latitude. Measured: `40.7128` was sent as `lat=40.71286`. Nothing errored; the API answered about somewhere else, and the size of the error depended on how many decimals the coordinate carried.

**`${api}/daily`** was right for only one of two callers. Per Weatherbit's docs the current endpoint is `/v2.0/current` and **there is no `/current/daily`**; the forecast is `/v2.0/forecast/daily`. Every current-weather request went to a path that does not exist.

## A failed upstream call took the server with it

The route was `async` and Express 4 does not catch a rejected promise from an async handler. The API modules `catch` and then `return err`, so an error object flowed on as data and the parsers iterated it.

| runtime | result |
| --- | --- |
| Node 14 | request **hangs**, no response (3020 ms) |
| Node 15+ | **process exits code 1** |

Parsers return empty results instead of throwing, an error middleware returns `502`, and the route validates input (`400` for a missing city or dates).

## Unescaped third-party text in innerHTML

Measured: a `previewURL` of `x' onerror='alert(1)` renders a live `onerror` handler. Not only injection: **real place names break it** too, since `L'Aquila`, `Val-d'Or` and `Martha's Vineyard` each end the single-quoted attribute.

New `escape.js`: `escapeHTML` covers `& < > " '` with the ampersand first; `safeURL` also rejects any scheme but `http`/`https`, since escaping does nothing about `javascript:alert(1)`.

## A validation function that could never say yes

`if (!data[subKey] || data[subKey] === 0) return false` returns `false` or `undefined`, never `true`. The only caller compensated with `=== false`, so the app worked by accident: written the obvious way, `if (!validateResponse(...))` rejected every city that *was* found.

## CORS, and the URL that forced it

`cors()` with no arguments sends `Access-Control-Allow-Origin: *` from a server whose only job is holding three API keys. It is an allowlist via `CORS_ORIGIN` now, defaulting to no cross-origin access. That was only necessary because the client posted to a hardcoded `http://localhost:8085`, so a deployed bundle could never reach its own server. Now `/api/travels`, verified in the built `dist`.

## Smaller, all real

- `path.resolve` called without importing `path`: `ReferenceError` on `GET /` under `npm run dev`.
- geonames over plain `http://`, credential in the query string. Now `https://secure.geonames.org/`.
- `getElementsByClassName.display = 'none'` sets a property on a **method** and does nothing.
- The forecast printed zero-based `getMonth()`, so March showed as `2`.
- Port hardcoded, no `server.on('error')`.
- Build toolchain in `dependencies`.
- `weatherGetCity` validated its config argument and then ignored it.

## Tests: none existed, and the runner could not start

`jest.config.js` named `jest-html-reporter`, which is in neither `package.json` nor the lockfile, and jest resolves reporters before running anything.

**51 tests, six suites**, every one poison-tested by reverting the fix and confirming the suite goes red:

| reintroduced bug | tests that fail |
| --- | --- |
| stray digit in the latitude | 1 |
| `current/daily` | 1 |
| `validateResponse` returning `undefined` | 9 |
| removing the error middleware | 6 |
| unescaped HTML | 3 |
| any URL scheme in `src` | 2 |
| parser throwing on empty | 4 |

Three setup traps are commented in `route.test.js`: `jest.mock(path)` with no factory does not work here (the transformer makes read-only getters); `jest.mock` is **not hoisted** above `import` (measured: 404 everywhere with `mock.calls.length` 0); the API modules capture keys at import time.

Lint is clean now; `npx eslint src` reported 3 errors on `master`.

## Node 14 to 20, not 22+

The build needs `NODE_OPTIONS=--openssl-legacy-provider` from Node 17. The server has a hard ceiling because it runs through `-r esm`, last published 2020: Node 14/16/18/20 serve `GET /` 200 and `POST /api/travels {}` 400, while Node 22/24 fail at startup in `esm.js` with `TypeError: Function.prototype.apply was called on undefined`. A dependency limit, not a code one.

## Dependencies genuinely unchanged

`package-lock.json` is **byte-identical to master**; `npm ci --ignore-scripts` installs the same 2060 packages before and after, verified on `node:14-alpine`.

Worth flagging: running `npm install --package-lock-only` to refresh the dev flags silently upgraded 17 transitive packages (`postcss 8.3.0 → 8.5.26`, `nanoid 3.1.23 → 3.3.18`), so the lockfile is left exactly as committed. The only cost is that its `dev` flags no longer describe the split perfectly, which affects nothing but an over-install under `--production`.

## Not covered

- **No live API calls.** Everything mocks `node-fetch` or the API modules, so URL construction and response handling are verified but the three services were never called.
- **`node-sass@4.14.1` fails its own postinstall** on `node:14-alpine` even with the build toolchain present, and does so identically on `master`.
- The service worker is unexamined.
- `geonames.js` and `pixabay.js` still ignore their config parameter the way `weatherbit.js` did. Left alone deliberately: nothing here needs to inject there, and changing a signature without a test to pin it is how the next defect gets in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved protection against unsafe HTML and URLs in displayed travel data.
  * Restricted cross-origin requests unless explicitly configured.

* **Bug Fixes**
  * Corrected weather forecast requests and handling of unavailable or malformed API responses.
  * Fixed same-origin travel request routing and invalid input validation.
  * Added configurable server port support.

* **Documentation**
  * Replaced the placeholder README with setup, architecture, usage, compatibility, and reliability guidance.

* **Tests**
  * Expanded coverage for security, API parsing, validation, routes, dates, and forecast requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->